### PR TITLE
[feat] Notice 도메인 API 문서화

### DIFF
--- a/module-app/app-api/src/main/java/com/chaing/api/config/SwaggerConfig.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/config/SwaggerConfig.java
@@ -118,4 +118,12 @@ public class SwaggerConfig {
                 .pathsToMatch("/api/v1/franchise/product/**")
                 .build();
     }
+
+    @Bean
+    public GroupedOpenApi noticeApi() {
+        return GroupedOpenApi.builder()
+                .group("공지사항(Notice)")
+                .pathsToMatch("/api/v1/notices/**")
+                .build();
+    }
 }

--- a/module-app/app-api/src/main/java/com/chaing/api/controller/notice/NoticeController.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/controller/notice/NoticeController.java
@@ -1,0 +1,67 @@
+package com.chaing.api.controller.notice;
+
+import com.chaing.api.dto.notice.request.CreateNoticeRequest;
+import com.chaing.api.dto.notice.request.UpdateNoticeRequest;
+import com.chaing.api.dto.notice.response.CreateNoticeResponse;
+import com.chaing.api.dto.notice.response.NoticeDetailResponse;
+import com.chaing.api.dto.notice.response.NoticeSummaryResponse;
+import com.chaing.core.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@Tag(name = "Notice API", description = "공지사항 API")
+@RequestMapping("/api/v1/notices")
+public class NoticeController {
+
+    @Operation(summary = "공지사항 등록", description = "본사 관리자가 새로운 공지사항 등록")
+    @PostMapping
+    public ResponseEntity<ApiResponse<CreateNoticeResponse>> createNotice(
+            @Valid @RequestBody CreateNoticeRequest request
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(CreateNoticeResponse.builder().build()));
+    }
+
+    @Operation(summary = "공지사항 목록 조회", description = "전체 공지사항 목록 조회")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<NoticeSummaryResponse>>> getNotices() {
+        return ResponseEntity.ok(ApiResponse.success(List.of(NoticeSummaryResponse.builder().build())));
+    }
+
+    @Operation(summary = "공지사항 상세 조회", description = "특정 공지사항의 상세 내용 조회")
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<NoticeDetailResponse>> getNoticeDetail(
+            @PathVariable Long id
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(NoticeDetailResponse.builder().build()));
+    }
+
+    @Operation(summary = "공지사항 수정", description = "특정 공지사항 내용 수정")
+    @PatchMapping("/{id}")
+    public ResponseEntity<ApiResponse<NoticeDetailResponse>> updateNotice(
+            @PathVariable Long id,
+            @Valid @RequestBody UpdateNoticeRequest request
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(NoticeDetailResponse.builder().build()));
+    }
+
+    @Operation(summary = "공지사항 삭제", description = "특정 공지사항 삭제")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> deleteNotice(
+            @PathVariable Long id
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+}

--- a/module-app/app-api/src/main/java/com/chaing/api/dto/notice/request/CreateNoticeRequest.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/dto/notice/request/CreateNoticeRequest.java
@@ -1,0 +1,4 @@
+package com.chaing.api.dto.notice.request;
+
+public record CreateNoticeRequest() {
+}

--- a/module-app/app-api/src/main/java/com/chaing/api/dto/notice/request/UpdateNoticeRequest.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/dto/notice/request/UpdateNoticeRequest.java
@@ -1,0 +1,4 @@
+package com.chaing.api.dto.notice.request;
+
+public record UpdateNoticeRequest() {
+}

--- a/module-app/app-api/src/main/java/com/chaing/api/dto/notice/response/CreateNoticeResponse.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/dto/notice/response/CreateNoticeResponse.java
@@ -1,0 +1,7 @@
+package com.chaing.api.dto.notice.response;
+
+import lombok.Builder;
+
+@Builder
+public record CreateNoticeResponse() {
+}

--- a/module-app/app-api/src/main/java/com/chaing/api/dto/notice/response/NoticeDetailResponse.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/dto/notice/response/NoticeDetailResponse.java
@@ -1,0 +1,7 @@
+package com.chaing.api.dto.notice.response;
+
+import lombok.Builder;
+
+@Builder
+public record NoticeDetailResponse() {
+}

--- a/module-app/app-api/src/main/java/com/chaing/api/dto/notice/response/NoticeSummaryResponse.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/dto/notice/response/NoticeSummaryResponse.java
@@ -1,0 +1,7 @@
+package com.chaing.api.dto.notice.response;
+
+import lombok.Builder;
+
+@Builder
+public record NoticeSummaryResponse() {
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
- Closes #46 

## 📝 작업 내용
- [x] Notice API 명세 작성
- [x] Swagger 그룹 설정

## 📸 스크린샷 (선택)
<img width="1301" height="321" alt="image" src="https://github.com/user-attachments/assets/14dc25f2-fef1-49a9-9c76-7cf35ec41a73" />

## ✅ 테스트 결과
- [ ] 단위 테스트 (JUnit)
- [ ] 통합 테스트
- [x] Swagger 테스트

---
### ✅ 변경 사항 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했나요?
- [x] 불필요한 공백이나 주석을 제거했나요?
- [ ] 코드에 영향이 있는 부분에 대해 테스트를 작성했나요?
- [ ] 모든 테스트가 성공했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **공지사항 관리 API 추가**: 공지사항 목록 조회, 상세 조회, 생성, 수정, 삭제 기능을 제공하는 REST API 엔드포인트 추가
* **API 문서화**: Swagger를 통한 공지사항 API 자동 문서화 및 명세 노출

<!-- end of auto-generated comment: release notes by coderabbit.ai -->