### PR TITLE
[feat] Notice 도메인 API 구현

### DIFF
--- a/module-app/app-api/src/main/java/com/chaing/api/controller/notice/NoticeController.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/controller/notice/NoticeController.java
@@ -2,14 +2,20 @@ package com.chaing.api.controller.notice;
 
 import com.chaing.api.dto.notice.request.CreateNoticeRequest;
 import com.chaing.api.dto.notice.request.UpdateNoticeRequest;
-import com.chaing.api.dto.notice.response.CreateNoticeResponse;
 import com.chaing.api.dto.notice.response.NoticeDetailResponse;
 import com.chaing.api.dto.notice.response.NoticeSummaryResponse;
+import com.chaing.api.facade.notice.NoticeFacade;
+import com.chaing.api.security.principal.UserPrincipal;
 import com.chaing.core.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -22,22 +28,29 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
+@RequiredArgsConstructor
 @Tag(name = "Notice API", description = "공지사항 API")
 @RequestMapping("/api/v1/notices")
 public class NoticeController {
 
+    private final NoticeFacade noticeFacade;
+
+    @PreAuthorize("hasRole('HQ')")
     @Operation(summary = "공지사항 등록", description = "본사 관리자가 새로운 공지사항 등록")
     @PostMapping
-    public ResponseEntity<ApiResponse<CreateNoticeResponse>> createNotice(
-            @Valid @RequestBody CreateNoticeRequest request
+    public ResponseEntity<ApiResponse<NoticeDetailResponse>> createNotice(
+            @Valid @RequestBody CreateNoticeRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
     ) {
-        return ResponseEntity.ok(ApiResponse.success(CreateNoticeResponse.builder().build()));
+        return ResponseEntity.ok(ApiResponse.success(noticeFacade.createNotice(request, principal.getId())));
     }
 
     @Operation(summary = "공지사항 목록 조회", description = "전체 공지사항 목록 조회")
     @GetMapping
-    public ResponseEntity<ApiResponse<List<NoticeSummaryResponse>>> getNotices() {
-        return ResponseEntity.ok(ApiResponse.success(List.of(NoticeSummaryResponse.builder().build())));
+    public ResponseEntity<ApiResponse<Page<NoticeSummaryResponse>>> getNotices(
+            Pageable pageable
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(noticeFacade.getNoticeList(pageable)));
     }
 
     @Operation(summary = "공지사항 상세 조회", description = "특정 공지사항의 상세 내용 조회")
@@ -45,23 +58,27 @@ public class NoticeController {
     public ResponseEntity<ApiResponse<NoticeDetailResponse>> getNoticeDetail(
             @PathVariable Long id
     ) {
-        return ResponseEntity.ok(ApiResponse.success(NoticeDetailResponse.builder().build()));
+        return ResponseEntity.ok(ApiResponse.success(noticeFacade.getNoticeDetail(id)));
     }
 
+    @PreAuthorize("hasRole('HQ')")
     @Operation(summary = "공지사항 수정", description = "특정 공지사항 내용 수정")
     @PatchMapping("/{id}")
     public ResponseEntity<ApiResponse<NoticeDetailResponse>> updateNotice(
             @PathVariable Long id,
-            @Valid @RequestBody UpdateNoticeRequest request
+            @Valid @RequestBody UpdateNoticeRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
     ) {
-        return ResponseEntity.ok(ApiResponse.success(NoticeDetailResponse.builder().build()));
+        return ResponseEntity.ok(ApiResponse.success(noticeFacade.updateNotice(id, request, principal.getId())));
     }
 
+    @PreAuthorize("hasRole('HQ')")
     @Operation(summary = "공지사항 삭제", description = "특정 공지사항 삭제")
     @DeleteMapping("/{id}")
     public ResponseEntity<ApiResponse<Void>> deleteNotice(
             @PathVariable Long id
     ) {
+        noticeFacade.deleteNotice(id);
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/module-app/app-api/src/main/java/com/chaing/api/controller/notice/NoticeController.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/controller/notice/NoticeController.java
@@ -25,8 +25,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 @RestController
 @RequiredArgsConstructor
 @Tag(name = "Notice API", description = "공지사항 API")

--- a/module-app/app-api/src/main/java/com/chaing/api/dto/notice/request/CreateNoticeRequest.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/dto/notice/request/CreateNoticeRequest.java
@@ -1,4 +1,23 @@
 package com.chaing.api.dto.notice.request;
 
-public record CreateNoticeRequest() {
+import com.chaing.domain.notices.dto.command.NoticeCreateCommand;
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateNoticeRequest(
+
+        @NotBlank(message = "공지사항 제목은 필수입니다.")
+        String title,
+
+        @NotBlank(message = "공지사항 내용은 필수입니다.")
+        String content,
+
+        boolean important
+) {
+    public NoticeCreateCommand toCommand() {
+        return new NoticeCreateCommand(
+                this.title,
+                this.content,
+                this.important
+        );
+    }
 }

--- a/module-app/app-api/src/main/java/com/chaing/api/dto/notice/request/UpdateNoticeRequest.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/dto/notice/request/UpdateNoticeRequest.java
@@ -6,7 +6,7 @@ public record UpdateNoticeRequest(
 
         String title,
         String content,
-        boolean important
+        Boolean important
 ) {
     public NoticeUpdateCommand toCommand() {
         return new NoticeUpdateCommand(

--- a/module-app/app-api/src/main/java/com/chaing/api/dto/notice/request/UpdateNoticeRequest.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/dto/notice/request/UpdateNoticeRequest.java
@@ -1,4 +1,18 @@
 package com.chaing.api.dto.notice.request;
 
-public record UpdateNoticeRequest() {
+import com.chaing.domain.notices.dto.command.NoticeUpdateCommand;
+
+public record UpdateNoticeRequest(
+
+        String title,
+        String content,
+        boolean important
+) {
+    public NoticeUpdateCommand toCommand() {
+        return new NoticeUpdateCommand(
+                this.title,
+                this.content,
+                this.important
+        );
+    }
 }

--- a/module-app/app-api/src/main/java/com/chaing/api/dto/notice/response/CreateNoticeResponse.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/dto/notice/response/CreateNoticeResponse.java
@@ -1,7 +1,0 @@
-package com.chaing.api.dto.notice.response;
-
-import lombok.Builder;
-
-@Builder
-public record CreateNoticeResponse() {
-}

--- a/module-app/app-api/src/main/java/com/chaing/api/dto/notice/response/NoticeDetailResponse.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/dto/notice/response/NoticeDetailResponse.java
@@ -1,7 +1,22 @@
 package com.chaing.api.dto.notice.response;
 
+import com.chaing.domain.notices.entity.Notice;
 import lombok.Builder;
 
 @Builder
-public record NoticeDetailResponse() {
+public record NoticeDetailResponse(
+
+        String title,
+        String content,
+        Long authorId,
+        boolean important
+) {
+    public static NoticeDetailResponse from(Notice notice) {
+        return new NoticeDetailResponse(
+                notice.getTitle(),
+                notice.getContent(),
+                notice.getAuthorId(),
+                notice.isImportant()
+        );
+    }
 }

--- a/module-app/app-api/src/main/java/com/chaing/api/dto/notice/response/NoticeSummaryResponse.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/dto/notice/response/NoticeSummaryResponse.java
@@ -1,7 +1,20 @@
 package com.chaing.api.dto.notice.response;
 
+import com.chaing.domain.notices.entity.Notice;
 import lombok.Builder;
 
 @Builder
-public record NoticeSummaryResponse() {
+public record NoticeSummaryResponse(
+
+        String title,
+        Long authorId,
+        boolean important
+) {
+    public static NoticeSummaryResponse from(Notice notice) {
+        return new NoticeSummaryResponse(
+                notice.getTitle(),
+                notice.getAuthorId(),
+                notice.isImportant()
+        );
+    }
 }

--- a/module-app/app-api/src/main/java/com/chaing/api/facade/notice/NoticeFacade.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/facade/notice/NoticeFacade.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -34,7 +35,7 @@ public class NoticeFacade {
     }
 
     // 공지사항 등록
-    @Transactional
+    @Transactional(rollbackFor = Exception.class, propagation = Propagation.REQUIRES_NEW)
     public NoticeDetailResponse createNotice(CreateNoticeRequest request, Long authorId) {
         NoticeCreateCommand command = request.toCommand();
         Notice notice = noticeService.create(command, authorId);
@@ -43,7 +44,7 @@ public class NoticeFacade {
     }
 
     // 공지사항 수정
-    @Transactional
+    @Transactional(rollbackFor = Exception.class, propagation = Propagation.REQUIRES_NEW)
     public NoticeDetailResponse updateNotice(Long id, UpdateNoticeRequest request, Long updaterId) {
         NoticeUpdateCommand command = request.toCommand();
         Notice notice = noticeService.update(id, command, updaterId);
@@ -52,7 +53,7 @@ public class NoticeFacade {
     }
 
     // 공지사항 삭제
-    @Transactional
+    @Transactional(rollbackFor = Exception.class, propagation = Propagation.REQUIRES_NEW)
     public void deleteNotice(Long id) {
         noticeService.delete(id);
     }

--- a/module-app/app-api/src/main/java/com/chaing/api/facade/notice/NoticeFacade.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/facade/notice/NoticeFacade.java
@@ -1,0 +1,59 @@
+package com.chaing.api.facade.notice;
+
+import com.chaing.api.dto.notice.request.CreateNoticeRequest;
+import com.chaing.api.dto.notice.request.UpdateNoticeRequest;
+import com.chaing.api.dto.notice.response.NoticeDetailResponse;
+import com.chaing.api.dto.notice.response.NoticeSummaryResponse;
+import com.chaing.domain.notices.dto.command.NoticeCreateCommand;
+import com.chaing.domain.notices.dto.command.NoticeUpdateCommand;
+import com.chaing.domain.notices.entity.Notice;
+import com.chaing.domain.notices.service.NoticeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NoticeFacade {
+
+    private final NoticeService noticeService;
+
+    // 공지사항 상세 조회
+    public NoticeDetailResponse getNoticeDetail(Long id) {
+        Notice notice = noticeService.getById(id);
+        return NoticeDetailResponse.from(notice);
+    }
+
+    // 공지사항 목록 조회
+    public Page<NoticeSummaryResponse> getNoticeList(Pageable pageable) {
+        Page<Notice> notices = noticeService.getNoticeList(pageable);
+        return notices.map(NoticeSummaryResponse::from);
+    }
+
+    // 공지사항 등록
+    @Transactional
+    public NoticeDetailResponse createNotice(CreateNoticeRequest request, Long authorId) {
+        NoticeCreateCommand command = request.toCommand();
+        Notice notice = noticeService.create(command, authorId);
+        // TODO: 공지사항 알림 생성
+        return NoticeDetailResponse.from(notice);
+    }
+
+    // 공지사항 수정
+    @Transactional
+    public NoticeDetailResponse updateNotice(Long id, UpdateNoticeRequest request, Long authorId) {
+        NoticeUpdateCommand command = request.toCommand();
+        Notice notice = noticeService.update(id, command, authorId);
+        // TODO: 공지사항 알림 생성
+        return NoticeDetailResponse.from(notice);
+    }
+
+    // 공지사항 삭제
+    @Transactional
+    public void deleteNotice(Long id) {
+        noticeService.delete(id);
+    }
+}

--- a/module-app/app-api/src/main/java/com/chaing/api/facade/notice/NoticeFacade.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/facade/notice/NoticeFacade.java
@@ -44,9 +44,9 @@ public class NoticeFacade {
 
     // 공지사항 수정
     @Transactional
-    public NoticeDetailResponse updateNotice(Long id, UpdateNoticeRequest request, Long authorId) {
+    public NoticeDetailResponse updateNotice(Long id, UpdateNoticeRequest request, Long updaterId) {
         NoticeUpdateCommand command = request.toCommand();
-        Notice notice = noticeService.update(id, command, authorId);
+        Notice notice = noticeService.update(id, command, updaterId);
         // TODO: 공지사항 알림 생성
         return NoticeDetailResponse.from(notice);
     }

--- a/module-domain/domain-businessunits/src/main/java/com/chaing/domain/businessunits/entity/Factory.java
+++ b/module-domain/domain-businessunits/src/main/java/com/chaing/domain/businessunits/entity/Factory.java
@@ -19,12 +19,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
 public class Factory extends BaseEntity {
 
     @Id

--- a/module-domain/domain-businessunits/src/main/java/com/chaing/domain/businessunits/entity/Franchise.java
+++ b/module-domain/domain-businessunits/src/main/java/com/chaing/domain/businessunits/entity/Franchise.java
@@ -17,6 +17,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -26,6 +27,7 @@ import java.time.LocalTime;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
 public class Franchise extends BaseEntity {
 
     @Id

--- a/module-domain/domain-notices/src/main/java/com/chaing/domain/notices/dto/command/NoticeCreateCommand.java
+++ b/module-domain/domain-notices/src/main/java/com/chaing/domain/notices/dto/command/NoticeCreateCommand.java
@@ -1,0 +1,15 @@
+package com.chaing.domain.notices.dto.command;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record NoticeCreateCommand(
+
+        @NotBlank(message = "공지사항 제목은 필수입니다.")
+        String title,
+
+        @NotBlank(message = "공지사항 내용은 필수입니다.")
+        String content,
+
+        boolean important
+) {
+}

--- a/module-domain/domain-notices/src/main/java/com/chaing/domain/notices/dto/command/NoticeUpdateCommand.java
+++ b/module-domain/domain-notices/src/main/java/com/chaing/domain/notices/dto/command/NoticeUpdateCommand.java
@@ -1,0 +1,9 @@
+package com.chaing.domain.notices.dto.command;
+
+public record NoticeUpdateCommand(
+
+        String title,
+        String content,
+        boolean important
+) {
+}

--- a/module-domain/domain-notices/src/main/java/com/chaing/domain/notices/dto/command/NoticeUpdateCommand.java
+++ b/module-domain/domain-notices/src/main/java/com/chaing/domain/notices/dto/command/NoticeUpdateCommand.java
@@ -4,6 +4,6 @@ public record NoticeUpdateCommand(
 
         String title,
         String content,
-        boolean important
+        Boolean important
 ) {
 }

--- a/module-domain/domain-notices/src/main/java/com/chaing/domain/notices/entity/Notice.java
+++ b/module-domain/domain-notices/src/main/java/com/chaing/domain/notices/entity/Notice.java
@@ -1,6 +1,8 @@
 package com.chaing.domain.notices.entity;
 
 import com.chaing.core.entity.BaseEntity;
+import com.chaing.domain.notices.dto.command.NoticeCreateCommand;
+import com.chaing.domain.notices.dto.command.NoticeUpdateCommand;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -11,12 +13,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
 public class Notice extends BaseEntity {
 
     @Id
@@ -35,4 +39,20 @@ public class Notice extends BaseEntity {
     @Builder.Default
     @Column(nullable = false)
     private boolean important = false;
+
+    public static Notice createNotice(NoticeCreateCommand command, Long authorId) {
+        return Notice.builder()
+                .title(command.title())
+                .content(command.content())
+                .authorId(authorId)
+                .important(command.important())
+                .build();
+    }
+
+    public void updateNotice(NoticeUpdateCommand command, Long authorId) {
+        this.title = command.title();
+        this.content = command.content();
+        this.authorId = authorId;
+        this.important = command.important();
+    }
 }

--- a/module-domain/domain-notices/src/main/java/com/chaing/domain/notices/entity/Notice.java
+++ b/module-domain/domain-notices/src/main/java/com/chaing/domain/notices/entity/Notice.java
@@ -36,6 +36,8 @@ public class Notice extends BaseEntity {
     @Column(nullable = false)
     private Long authorId;
 
+    private Long updaterId;
+
     @Builder.Default
     @Column(nullable = false)
     private boolean important = false;
@@ -49,10 +51,10 @@ public class Notice extends BaseEntity {
                 .build();
     }
 
-    public void updateNotice(NoticeUpdateCommand command, Long authorId) {
+    public void updateNotice(NoticeUpdateCommand command, Long updaterId) {
         if (command.title() != null) this.title = command.title();
         if (command.content() != null) this.content = command.content();
-        this.authorId = authorId;
+        this.updaterId = updaterId;
         if (command.important() != null) this.important = command.important();
     }
 }

--- a/module-domain/domain-notices/src/main/java/com/chaing/domain/notices/entity/Notice.java
+++ b/module-domain/domain-notices/src/main/java/com/chaing/domain/notices/entity/Notice.java
@@ -53,6 +53,6 @@ public class Notice extends BaseEntity {
         this.title = command.title();
         this.content = command.content();
         this.authorId = authorId;
-        this.important = command.important();
+        if (command.important() != null) this.important = command.important();
     }
 }

--- a/module-domain/domain-notices/src/main/java/com/chaing/domain/notices/entity/Notice.java
+++ b/module-domain/domain-notices/src/main/java/com/chaing/domain/notices/entity/Notice.java
@@ -50,8 +50,8 @@ public class Notice extends BaseEntity {
     }
 
     public void updateNotice(NoticeUpdateCommand command, Long authorId) {
-        this.title = command.title();
-        this.content = command.content();
+        if (command.title() != null) this.title = command.title();
+        if (command.content() != null) this.content = command.content();
         this.authorId = authorId;
         if (command.important() != null) this.important = command.important();
     }

--- a/module-domain/domain-notices/src/main/java/com/chaing/domain/notices/exception/NoticeErrorCode.java
+++ b/module-domain/domain-notices/src/main/java/com/chaing/domain/notices/exception/NoticeErrorCode.java
@@ -1,0 +1,16 @@
+package com.chaing.domain.notices.exception;
+
+import com.chaing.core.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NoticeErrorCode implements ErrorCode {
+
+    NOTICE_NOT_FOUND(484, "N001", "해당 공지사항을 찾을 수 없습니다.");
+
+    private final Integer status;
+    private final String code;
+    private final String message;
+}

--- a/module-domain/domain-notices/src/main/java/com/chaing/domain/notices/exception/NoticeErrorCode.java
+++ b/module-domain/domain-notices/src/main/java/com/chaing/domain/notices/exception/NoticeErrorCode.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum NoticeErrorCode implements ErrorCode {
 
-    NOTICE_NOT_FOUND(484, "N001", "해당 공지사항을 찾을 수 없습니다.");
+    NOTICE_NOT_FOUND(404, "N001", "해당 공지사항을 찾을 수 없습니다.");
 
     private final Integer status;
     private final String code;

--- a/module-domain/domain-notices/src/main/java/com/chaing/domain/notices/exception/NoticeException.java
+++ b/module-domain/domain-notices/src/main/java/com/chaing/domain/notices/exception/NoticeException.java
@@ -1,0 +1,16 @@
+package com.chaing.domain.notices.exception;
+
+import com.chaing.core.exception.ErrorCode;
+import com.chaing.core.exception.GlobalException;
+import lombok.Getter;
+
+@Getter
+public class NoticeException extends GlobalException {
+
+    private final ErrorCode errorCode;
+
+    public NoticeException(ErrorCode errorCode) {
+        super(errorCode);
+        this.errorCode = errorCode;
+    }
+}

--- a/module-domain/domain-notices/src/main/java/com/chaing/domain/notices/repository/NoticeRepository.java
+++ b/module-domain/domain-notices/src/main/java/com/chaing/domain/notices/repository/NoticeRepository.java
@@ -1,0 +1,13 @@
+package com.chaing.domain.notices.repository;
+
+import com.chaing.domain.notices.entity.Notice;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NoticeRepository extends JpaRepository<Notice,Long> {
+
+    Page<Notice> findAllByOrderByImportantDescCreatedAtDesc(Pageable pageable);
+}

--- a/module-domain/domain-notices/src/main/java/com/chaing/domain/notices/service/NoticeService.java
+++ b/module-domain/domain-notices/src/main/java/com/chaing/domain/notices/service/NoticeService.java
@@ -1,0 +1,50 @@
+package com.chaing.domain.notices.service;
+
+import com.chaing.domain.notices.dto.command.NoticeCreateCommand;
+import com.chaing.domain.notices.dto.command.NoticeUpdateCommand;
+import com.chaing.domain.notices.entity.Notice;
+import com.chaing.domain.notices.exception.NoticeErrorCode;
+import com.chaing.domain.notices.exception.NoticeException;
+import com.chaing.domain.notices.repository.NoticeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeService {
+
+    private final NoticeRepository noticeRepository;
+
+    // 공지사항 상세 조회
+    public Notice getById(Long id) {
+        return noticeRepository.findById(id)
+                .orElseThrow(() -> new NoticeException(NoticeErrorCode.NOTICE_NOT_FOUND));
+    }
+
+    // 공지사항 목록 조회
+    public Page<Notice> getNoticeList(Pageable pageable) {
+        return noticeRepository.findAllByOrderByImportantDescCreatedAtDesc(pageable);
+    }
+
+    // 공지사항 등록
+    public Notice create(NoticeCreateCommand command, Long authorId) {
+        Notice notice = Notice.createNotice(command, authorId);
+        return noticeRepository.save(notice);
+    }
+
+    // 공지사항 수정
+    public Notice update(Long id, NoticeUpdateCommand command, Long authorId) {
+        Notice notice = getById(id);
+        notice.updateNotice(command, authorId);
+        return notice;
+    }
+
+
+    // 공지사항 삭제 - 본사
+    public void delete(Long id) {
+        Notice notice = getById(id);
+        notice.delete();
+    }
+}

--- a/module-domain/domain-notices/src/main/java/com/chaing/domain/notices/service/NoticeService.java
+++ b/module-domain/domain-notices/src/main/java/com/chaing/domain/notices/service/NoticeService.java
@@ -35,9 +35,9 @@ public class NoticeService {
     }
 
     // 공지사항 수정
-    public Notice update(Long id, NoticeUpdateCommand command, Long authorId) {
+    public Notice update(Long id, NoticeUpdateCommand command, Long updaterId) {
         Notice notice = getById(id);
-        notice.updateNotice(command, authorId);
+        notice.updateNotice(command, updaterId);
         return notice;
     }
 

--- a/module-domain/domain-notices/src/test/java/com/chaing/domain/notices/service/NoticeServiceTests.java
+++ b/module-domain/domain-notices/src/test/java/com/chaing/domain/notices/service/NoticeServiceTests.java
@@ -11,17 +11,24 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-class NoticeServiceTest {
+class NoticeServiceTests {
 
     @InjectMocks
     private NoticeService noticeService;
@@ -57,6 +64,39 @@ class NoticeServiceTest {
         // then
         assertThat(result).isNotNull();
         verify(noticeRepository, times(1)).save(any(Notice.class));
+    }
+
+    @Test
+    @DisplayName("공지사항 목록 조회")
+    void getNoticeList() {
+
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+        ReflectionTestUtils.setField(notice, "createdAt", LocalDateTime.now().minusDays(1));
+
+        Notice importantNotice = Notice.builder()
+                .title("중요 공지")
+                .important(true)
+                .authorId(authorId)
+                .build();
+        ReflectionTestUtils.setField(importantNotice, "createdAt", LocalDateTime.now());
+
+        List<Notice> notices = List.of(importantNotice, notice);
+        Page<Notice> noticePage = new PageImpl<>(notices, pageable, notices.size());
+
+        given(noticeRepository.findAllByOrderByImportantDescCreatedAtDesc(pageable)).willReturn(noticePage);
+
+        // when
+        Page<Notice> result = noticeService.getNoticeList(pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent().get(0).getTitle()).isEqualTo("중요 공지");
+        assertThat(result.getContent().get(0).isImportant()).isTrue();
+        assertThat(result.getContent().get(1).getTitle()).isEqualTo("제목");
+        assertThat(result.getContent().get(1).isImportant()).isFalse();
+
+        verify(noticeRepository, times(1)).findAllByOrderByImportantDescCreatedAtDesc(pageable);
     }
 
     @Test

--- a/module-domain/domain-notices/src/test/java/com/chaing/domain/notices/service/NoticeServiceTests.java
+++ b/module-domain/domain-notices/src/test/java/com/chaing/domain/notices/service/NoticeServiceTests.java
@@ -47,6 +47,7 @@ class NoticeServiceTests {
                 .content("내용")
                 .important(false)
                 .authorId(authorId)
+                .updaterId(null)
                 .build();
     }
 
@@ -118,15 +119,18 @@ class NoticeServiceTests {
     void update() {
 
         // given
+        Long updaterId = 2L;
         NoticeUpdateCommand command = new NoticeUpdateCommand("수정된 제목", "수정된 내용", true);
         given(noticeRepository.findById(noticeId)).willReturn(Optional.of(notice));
 
         // when
-        Notice result = noticeService.update(noticeId, command, authorId);
+        Notice result = noticeService.update(noticeId, command, updaterId);
 
         // then
         assertThat(result.getTitle()).isEqualTo("수정된 제목");
         assertThat(result.isImportant()).isTrue();
+        assertThat(result.getAuthorId()).isEqualTo(1L);
+        assertThat(result.getUpdaterId()).isEqualTo(2L);
     }
 
     @Test

--- a/module-domain/domain-notices/src/test/java/com/chaing/domain/notices/service/NoticeServiceTests.java
+++ b/module-domain/domain-notices/src/test/java/com/chaing/domain/notices/service/NoticeServiceTests.java
@@ -1,0 +1,105 @@
+package com.chaing.domain.notices.service;
+
+import com.chaing.domain.notices.dto.command.NoticeCreateCommand;
+import com.chaing.domain.notices.dto.command.NoticeUpdateCommand;
+import com.chaing.domain.notices.entity.Notice;
+import com.chaing.domain.notices.repository.NoticeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class NoticeServiceTest {
+
+    @InjectMocks
+    private NoticeService noticeService;
+
+    @Mock
+    private NoticeRepository noticeRepository;
+
+    private Notice notice;
+    private final Long authorId = 1L;
+    private final Long noticeId = 1L;
+
+    @BeforeEach
+    void setUp() {
+        notice = Notice.builder()
+                .title("제목")
+                .content("내용")
+                .important(false)
+                .authorId(authorId)
+                .build();
+    }
+
+    @Test
+    @DisplayName("공지사항 등록")
+    void create() {
+
+        // given
+        NoticeCreateCommand command = new NoticeCreateCommand("신규 공지", "내용", true);
+        given(noticeRepository.save(any(Notice.class))).willReturn(notice);
+
+        // when
+        Notice result = noticeService.create(command, authorId);
+
+        // then
+        assertThat(result).isNotNull();
+        verify(noticeRepository, times(1)).save(any(Notice.class));
+    }
+
+    @Test
+    @DisplayName("공지사항 상세 조회")
+    void getById() {
+
+        // given
+        given(noticeRepository.findById(noticeId)).willReturn(Optional.of(notice));
+
+        // when
+        Notice result = noticeService.getById(noticeId);
+
+        // then
+        assertThat(result.getTitle()).isEqualTo("제목");
+    }
+
+    @Test
+    @DisplayName("공지사항 수정")
+    void update() {
+
+        // given
+        NoticeUpdateCommand command = new NoticeUpdateCommand("수정된 제목", "수정된 내용", true);
+        given(noticeRepository.findById(noticeId)).willReturn(Optional.of(notice));
+
+        // when
+        Notice result = noticeService.update(noticeId, command, authorId);
+
+        // then
+        assertThat(result.getTitle()).isEqualTo("수정된 제목");
+        assertThat(result.isImportant()).isTrue();
+    }
+
+    @Test
+    @DisplayName("공지사항 삭제")
+    void delete() {
+
+        // given
+        given(noticeRepository.findById(noticeId)).willReturn(Optional.of(notice));
+
+        // when
+        noticeService.delete(noticeId);
+
+        // then
+        verify(noticeRepository, times(1)).findById(noticeId);
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
- Closes #84 

## 📝 작업 내용
- [x] Notice API 구현
- [x] 테스트 코드 작성

## 📸 스크린샷 (선택)
<img width="300" height="185" alt="image" src="https://github.com/user-attachments/assets/c1dbdd10-894e-4300-9f01-458230aea185" />

## ✅ 테스트 결과
- [x] 단위 테스트 (JUnit)
- [ ] 통합 테스트

---
### ✅ 변경 사항 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했나요?
- [x] 불필요한 공백이나 주석을 제거했나요?
- [x] 코드에 영향이 있는 부분에 대해 테스트를 작성했나요?
- [x] 모든 테스트가 성공했나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 공지사항 CRUD 전면 도입: 생성·목록(페이징)·상세·수정·삭제 제공, 목록은 중요도 우선 정렬
  * 생성/수정 시 상세 응답 반환 및 페이징 응답 지원

* **유효성 검사**
  * 공지 제목/내용 필수 검증 추가

* **보안**
  * 인증 연동 및 HQ 권한으로 수정·삭제 제한

* **도메인/예외**
  * 전역 삭제 필터 적용(삭제된 항목 제외) 및 전용 오류 코드/예외 추가

* **테스트**
  * 공지 서비스 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->