### PR TITLE
[feat] 반품 차량 배정 api 구현 및 프론트 연동

### DIFF
--- a/module-app/app-api/src/main/java/com/chaing/api/controller/transport/InternalTransportController.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/controller/transport/InternalTransportController.java
@@ -78,22 +78,14 @@ public class    InternalTransportController {
         return ResponseEntity.ok(ApiResponse.success((transportFacade.getUnassignedReturns())));
     }
 
-//    @Operation(summary = "반품 차량 배정", description = "차량 미배정 반품 건에 차량을 배정한다.")
+    @Operation(summary = "반품 차량 배정", description = "차량 미배정 반품 건에 차량을 배정한다.")
+    @PostMapping("/returns/assignments")
+    public ResponseEntity<ApiResponse<Void>> assignReturns(
+            @Valid @RequestBody VehicleAssignmentRequest request
+    ) {
+        transportFacade.assignVehicleReturns(request);
 
-    // 고려 사항으로 인해 추후 구현
-/*    @Operation(summary = "입고 승인 상태 변경", description = "입고 승인 시 상태 변경")
-    @PatchMapping("/{transportId}/arrival-approve")
-    public ResponseEntity<ApiResponse<?>> approveArrival(
-            @PathVariable Long transportId, @RequestBody ArrivalApprovalRequest req) {
-        // TODO: 상태 변경 로직 (예: ARRIVED)
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
-    @Operation(summary = "상태 강제 수정", description = "운송 및 차량 상태 강제 수정")
-    @PutMapping("/{transportId}/force-update")
-    public ResponseEntity<ApiResponse<?>> forceUpdateStatus(
-            @PathVariable Long transportId, @RequestBody TransportForceUpdateRequest req) {
-        // TODO: 강제 수정 로직
-        return ResponseEntity.ok(ApiResponse.success(null));
-    }*/
 }

--- a/module-app/app-api/src/main/java/com/chaing/api/controller/transport/InternalTransportController.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/controller/transport/InternalTransportController.java
@@ -4,6 +4,7 @@ import com.chaing.api.dto.transport.internal.request.VehicleAssignmentRequest;
 import com.chaing.api.dto.transport.internal.response.AvailableVehicleResponse;
 import com.chaing.api.dto.transport.internal.response.TransportCancelResponse;
 import com.chaing.api.dto.transport.internal.response.UnassignedOrderResponse;
+import com.chaing.api.dto.transport.internal.response.UnassignedReturnResponse;
 import com.chaing.api.facade.transport.InternalTransportFacade;
 import com.chaing.core.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -29,7 +30,7 @@ public class    InternalTransportController {
 
     private final InternalTransportFacade transportFacade;
 
-    @Operation(summary = "운송 가능 차량 조회", description = "배차 가능 차량 리스트 출력한다.")
+    @Operation(summary = "발주 운송 가능 차량 조회", description = "발주 건에 배차 가능 차량 리스트 출력한다.")
     @GetMapping("/available-vehicles")
     public ResponseEntity<ApiResponse<List<AvailableVehicleResponse>>> getAvailableVehicles() {
 
@@ -45,7 +46,7 @@ public class    InternalTransportController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    @Operation(summary = "차량 배정", description = "미배정 주문 차량 배정한다.")
+    @Operation(summary = "발주 차량 배정", description = "차량 미배정 발주 건에 차량 배정한다.")
     @PostMapping("/assignments")
     public ResponseEntity<ApiResponse<Void>> assignVehicle(
             @Valid @RequestBody VehicleAssignmentRequest request) {
@@ -64,6 +65,20 @@ public class    InternalTransportController {
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }
+
+    @Operation(summary = "반품 운송 가능 차량 조회", description = "반품 건에 배차 가능 차량 리스트 출력한다.")
+    @GetMapping("/returns/available-vehicles")
+    public ResponseEntity<ApiResponse<List<AvailableVehicleResponse>>> getReturnAvailableVehicles() {
+        return ResponseEntity.ok(ApiResponse.success(transportFacade.getVehicleForReturn()));
+    }
+
+    @Operation(summary = "차량 미배정 반품 목록 조회", description = "차량이 배정되지 않은 반품 목록을 조회한다.")
+    @GetMapping("/unassigned-returns")
+    public ResponseEntity<ApiResponse<List<UnassignedReturnResponse>>> getUnassignedReturns() {
+        return ResponseEntity.ok(ApiResponse.success((transportFacade.getUnassignedReturns())));
+    }
+
+//    @Operation(summary = "반품 차량 배정", description = "차량 미배정 반품 건에 차량을 배정한다.")
 
     // 고려 사항으로 인해 추후 구현
 /*    @Operation(summary = "입고 승인 상태 변경", description = "입고 승인 시 상태 변경")

--- a/module-app/app-api/src/main/java/com/chaing/api/dto/transport/internal/request/VehicleAssignmentRequest.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/dto/transport/internal/request/VehicleAssignmentRequest.java
@@ -8,6 +8,6 @@ public record VehicleAssignmentRequest(
         @NotNull(message = "차량을 선택해주세요")
         Long vehicleId,
         @NotNull(message = "주문을 선택해주세요")
-        List<Long> orderIds
+        List<Long> selectedIds
 ) {
 }

--- a/module-app/app-api/src/main/java/com/chaing/api/dto/transport/internal/request/VehicleAssignmentRequest.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/dto/transport/internal/request/VehicleAssignmentRequest.java
@@ -1,5 +1,6 @@
 package com.chaing.api.dto.transport.internal.request;
 
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
@@ -7,7 +8,7 @@ import java.util.List;
 public record VehicleAssignmentRequest(
         @NotNull(message = "차량을 선택해주세요")
         Long vehicleId,
-        @NotNull(message = "주문을 선택해주세요")
+        @NotEmpty(message = "주문을 선택해주세요")
         List<Long> selectedIds
 ) {
 }

--- a/module-app/app-api/src/main/java/com/chaing/api/dto/transport/internal/response/AvailableVehicleResponse.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/dto/transport/internal/response/AvailableVehicleResponse.java
@@ -1,24 +1,31 @@
 package com.chaing.api.dto.transport.internal.response;
 
+import com.chaing.domain.transports.dto.response.AvailableVehicleInfo;
 import com.chaing.domain.transports.entity.Vehicle;
 import lombok.Builder;
 
 @Builder
 public record AvailableVehicleResponse(
-        Long vehicleId,         // 차량 고유 ID
-        String vehicleNumber,   // 차량 번호
-        Long maxLoad,           // 최대 적재량
-        Long currentLoad,       // 현재 적재량
-        Long availableLoad      // 적재 가능 잔여량 (max - current)
+        String transportName,       // 업체명
+        String driverName,          // 운전자명
+        String driverPhoneNumber,   // 전화번호
+        Long vehicleId,             // 차량 고유 ID
+        String vehicleNumber,       // 차량 번호
+        Long maxLoad,               // 최대 적재량
+        Long currentLoad,           // 현재 적재량
+        Long availableLoad          // 적재 가능 잔여량 (max - current)
 ) {
-    public static AvailableVehicleResponse from(Vehicle vehicle, Long currentLoad) {
-            long safeCurrentLoad = currentLoad == null ? 0L : currentLoad;
-            long safeMaxLoad = vehicle.getMaxLoad() == null ? 0L : vehicle.getMaxLoad();
+    public static AvailableVehicleResponse from(AvailableVehicleInfo vehicleInfo) {
+            long safeCurrentLoad = vehicleInfo.currentLoad() == null ? 0L : vehicleInfo.currentLoad();
+            long safeMaxLoad = vehicleInfo.maxLoad() == null ? 0L : vehicleInfo.maxLoad();
             long safeAvailableLoad = Math.max(0L, safeMaxLoad - safeCurrentLoad);
 
         return AvailableVehicleResponse.builder()
-                .vehicleId(vehicle.getVehicleId())
-                .vehicleNumber(vehicle.getVehicleNumber())
+                .transportName(vehicleInfo.transportName())
+                .driverName(vehicleInfo.driverName())
+                .driverPhoneNumber(vehicleInfo.driverPhoneNumber())
+                .vehicleId(vehicleInfo.vehicleId())
+                .vehicleNumber(vehicleInfo.vehicleNumber())
                 .maxLoad(safeMaxLoad)
                 .currentLoad(safeCurrentLoad)
                 .availableLoad(safeAvailableLoad)

--- a/module-app/app-api/src/main/java/com/chaing/api/dto/transport/internal/response/UnassignedReturnResponse.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/dto/transport/internal/response/UnassignedReturnResponse.java
@@ -1,0 +1,24 @@
+package com.chaing.api.dto.transport.internal.response;
+
+import com.chaing.domain.businessunits.dto.internal.BusinessUnitInternal;
+import com.chaing.domain.returns.dto.command.HQReturnCommand;
+
+import java.time.LocalDateTime;
+
+public record UnassignedReturnResponse(
+        String returnCode,
+        String franchiseName,
+        String address,
+        LocalDateTime requestedDate
+        ) {
+    public static UnassignedReturnResponse from(
+            HQReturnCommand returnInfo, BusinessUnitInternal franchiseInfo
+    ) {
+        return new UnassignedReturnResponse(
+                returnInfo.returnCode(),
+                franchiseInfo.name(),
+                franchiseInfo.address(),
+                returnInfo.requestedDate()
+        );
+    }
+}

--- a/module-app/app-api/src/main/java/com/chaing/api/dto/transport/internal/response/UnassignedReturnResponse.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/dto/transport/internal/response/UnassignedReturnResponse.java
@@ -6,6 +6,7 @@ import com.chaing.domain.returns.dto.command.HQReturnCommand;
 import java.time.LocalDateTime;
 
 public record UnassignedReturnResponse(
+        Long returnId,
         String returnCode,
         String franchiseName,
         String address,
@@ -15,6 +16,7 @@ public record UnassignedReturnResponse(
             HQReturnCommand returnInfo, BusinessUnitInternal franchiseInfo
     ) {
         return new UnassignedReturnResponse(
+                returnInfo.returnId(),
                 returnInfo.returnCode(),
                 franchiseInfo.name(),
                 franchiseInfo.address(),

--- a/module-app/app-api/src/main/java/com/chaing/api/facade/transport/InternalTransportFacade.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/facade/transport/InternalTransportFacade.java
@@ -212,7 +212,11 @@ public class InternalTransportFacade {
 
         List<FranchiseReturnCommandForTransit> returns = franchisereturnService.getReturnForTransit(request.selectedIds());
 
-        List<Long> orderIds = returns.stream().map(FranchiseReturnCommandForTransit::franchiseId).toList();
+        List<Long> orderIds = returns.stream().map(FranchiseReturnCommandForTransit::franchiseOrderId).toList();
+
+        for(Long orderId : orderIds) {
+            System.out.println("orderId = " + orderId);
+        }
 
         List<FranchiseOrderForTransitResponse> orders = franchiseOrderService.getOrdersForTransit(orderIds);
 
@@ -231,7 +235,7 @@ public class InternalTransportFacade {
         // 송장 번호 가져오기
         Map<String, String> trackingMap = Map.of(
                 "SE0320260207001", "TRACK-12345",
-                "ORD002", "TRACK-67890"
+                "SE0120260207002", "TRACK-67890"
         );
                 /* 외부 운송 모듈 구현 전 임시 값으로 대체
                 externalTrackingModule.getTrackingNumbers(

--- a/module-app/app-api/src/main/java/com/chaing/api/facade/transport/InternalTransportFacade.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/facade/transport/InternalTransportFacade.java
@@ -214,10 +214,6 @@ public class InternalTransportFacade {
 
         List<Long> orderIds = returns.stream().map(FranchiseReturnCommandForTransit::franchiseOrderId).toList();
 
-        for(Long orderId : orderIds) {
-            System.out.println("orderId = " + orderId);
-        }
-
         List<FranchiseOrderForTransitResponse> orders = franchiseOrderService.getOrdersForTransit(orderIds);
 
         List<OrderInfo> orderInfos = getOrderInfos(orders);

--- a/module-app/app-api/src/main/java/com/chaing/api/facade/transport/InternalTransportFacade.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/facade/transport/InternalTransportFacade.java
@@ -16,10 +16,12 @@ import com.chaing.domain.returns.dto.command.HQReturnCommand;
 import com.chaing.domain.returns.service.FranchiseReturnService;
 import com.chaing.domain.transports.dto.DeliveryFeeInfo;
 import com.chaing.domain.transports.dto.OrderInfo;
+import com.chaing.domain.returns.dto.command.FranchiseReturnCommandForTransit;
 import com.chaing.domain.transports.dto.response.AvailableVehicleInfo;
 import com.chaing.domain.transports.exception.TransportErrorCode;
 import com.chaing.domain.transports.exception.TransportException;
 import com.chaing.domain.transports.service.InternalTransportService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -71,7 +73,7 @@ public class InternalTransportFacade {
 
         // 발주 도메인
         // 발주 Id, 중량 정보 받아오기
-        List<FranchiseOrderForTransitResponse> orders = franchiseOrderService.getOrdersForTransit(request.orderIds());
+        List<FranchiseOrderForTransitResponse> orders = franchiseOrderService.getOrdersForTransit(request.selectedIds());
 
         // 상품 Id 추출
         List<OrderInfo> orderInfos = getOrderInfos(orders);
@@ -202,5 +204,46 @@ public class InternalTransportFacade {
                     return UnassignedReturnResponse.from(returnInfo, franchiseInfo);
                 })
                 .collect(Collectors.toList());
+    }
+
+    // 반품 차량 배정
+    @Transactional
+    public void assignVehicleReturns(@Valid VehicleAssignmentRequest request) {
+
+        List<FranchiseReturnCommandForTransit> returns = franchisereturnService.getReturnForTransit(request.selectedIds());
+
+        List<Long> orderIds = returns.stream().map(FranchiseReturnCommandForTransit::franchiseId).toList();
+
+        List<FranchiseOrderForTransitResponse> orders = franchiseOrderService.getOrdersForTransit(orderIds);
+
+        List<OrderInfo> orderInfos = getOrderInfos(orders);
+
+        // 선택된 발주의 총 무게 계산
+        Long totalWeight = orderInfos.stream()
+                .mapToLong(OrderInfo::weight)
+                .sum();
+
+        List<String> returnCodes = returns.stream()
+                .map(FranchiseReturnCommandForTransit::returnCode)
+                .toList();
+
+        // 외부 운송 모듈
+        // 송장 번호 가져오기
+        Map<String, String> trackingMap = Map.of(
+                "SE0320260207001", "TRACK-12345",
+                "ORD002", "TRACK-67890"
+        );
+                /* 외부 운송 모듈 구현 전 임시 값으로 대체
+                externalTrackingModule.getTrackingNumbers(
+                orderInfos.stream().map(OrderInfo::orderCode).toList()
+        );*/
+
+        transportService.assignVehicleReturn(
+                request.vehicleId(),
+                orderInfos,
+                trackingMap,     // String
+                totalWeight,
+                returnCodes
+        );
     }
 }

--- a/module-app/app-api/src/main/java/com/chaing/api/facade/transport/InternalTransportFacade.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/facade/transport/InternalTransportFacade.java
@@ -41,7 +41,7 @@ public class InternalTransportFacade {
     private final FranchiseOrderService franchiseOrderService;
     private final ProductService productService;
     private final BusinessUnitService franchiseServiceImpl;
-    private final FranchiseReturnService franchisereturnService;
+    private final FranchiseReturnService franchiseReturnService;
 
     // 운송 가능 차량 리스트 조회
     public List<AvailableVehicleResponse> getAvailableVehicle() {
@@ -187,7 +187,7 @@ public class InternalTransportFacade {
 
     public List<UnassignedReturnResponse> getUnassignedReturns() {
 
-        Map<Long, HQReturnCommand> returnCommandMap = franchisereturnService.getAllReturnByStatus(ACCEPTED);
+        Map<Long, HQReturnCommand> returnCommandMap = franchiseReturnService.getAllReturnByStatus(ACCEPTED);
 
         Map<Long, BusinessUnitInternal> franchiseMap = returnCommandMap.values().stream()
                 .map(command -> franchiseServiceImpl.getById(command.franchiseId()))
@@ -210,7 +210,7 @@ public class InternalTransportFacade {
     @Transactional
     public void assignVehicleReturns(@Valid VehicleAssignmentRequest request) {
 
-        List<FranchiseReturnCommandForTransit> returns = franchisereturnService.getReturnForTransit(request.selectedIds());
+        List<FranchiseReturnCommandForTransit> returns = franchiseReturnService.getReturnForTransit(request.selectedIds());
 
         List<Long> orderIds = returns.stream().map(FranchiseReturnCommandForTransit::franchiseOrderId).toList();
 

--- a/module-app/app-api/src/main/java/com/chaing/api/facade/transport/InternalTransportFacade.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/facade/transport/InternalTransportFacade.java
@@ -4,6 +4,7 @@ import com.chaing.api.dto.transport.internal.request.VehicleAssignmentRequest;
 import com.chaing.api.dto.transport.internal.response.AvailableVehicleResponse;
 import com.chaing.api.dto.transport.internal.response.TransportCancelResponse;
 import com.chaing.api.dto.transport.internal.response.UnassignedOrderResponse;
+import com.chaing.api.dto.transport.internal.response.UnassignedReturnResponse;
 import com.chaing.domain.businessunits.dto.internal.BusinessUnitInternal;
 import com.chaing.domain.businessunits.exception.BusinessUnitErrorCode;
 import com.chaing.domain.businessunits.exception.BusinessUnitException;
@@ -11,6 +12,8 @@ import com.chaing.domain.businessunits.service.BusinessUnitService;
 import com.chaing.domain.orders.dto.response.FranchiseOrderForTransitResponse;
 import com.chaing.domain.orders.service.FranchiseOrderService;
 import com.chaing.domain.products.service.ProductService;
+import com.chaing.domain.returns.dto.command.HQReturnCommand;
+import com.chaing.domain.returns.service.FranchiseReturnService;
 import com.chaing.domain.transports.dto.DeliveryFeeInfo;
 import com.chaing.domain.transports.dto.OrderInfo;
 import com.chaing.domain.transports.dto.response.AvailableVehicleInfo;
@@ -25,6 +28,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.chaing.domain.returns.enums.ReturnStatus.ACCEPTED;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -34,6 +39,7 @@ public class InternalTransportFacade {
     private final FranchiseOrderService franchiseOrderService;
     private final ProductService productService;
     private final BusinessUnitService franchiseServiceImpl;
+    private final FranchiseReturnService franchisereturnService;
 
     // 운송 가능 차량 리스트 조회
     public List<AvailableVehicleResponse> getAvailableVehicle() {
@@ -43,9 +49,12 @@ public class InternalTransportFacade {
         return domainResponses.stream()
                 .map(res -> {
                     long safeMaxLoad = res.maxLoad() == null ? 0L : Math.max(0L, res.maxLoad());
-                    long safeCurrentLoad = res.currentWeight() == null ? 0L : Math.max(0L, res.currentWeight());
+                    long safeCurrentLoad = res.currentLoad() == null ? 0L : Math.max(0L, res.currentLoad());
                     long safeAvailableLoad = Math.max(0L, safeMaxLoad - safeCurrentLoad);
                     return new AvailableVehicleResponse(
+                            res.transportName(),
+                            res.driverName(),
+                            res.driverPhoneNumber(),
                             res.vehicleId(),
                             res.vehicleNumber(),
                             safeMaxLoad,
@@ -166,4 +175,32 @@ public class InternalTransportFacade {
                 .toList();
     }
 
+    public List<AvailableVehicleResponse> getVehicleForReturn() {
+        List<AvailableVehicleInfo> domainResponses = transportService.getAllAvailableVehicle();
+
+        return domainResponses.stream()
+                .map(AvailableVehicleResponse::from)
+                .toList();
+    }
+
+    public List<UnassignedReturnResponse> getUnassignedReturns() {
+
+        Map<Long, HQReturnCommand> returnCommandMap = franchisereturnService.getAllReturnByStatus(ACCEPTED);
+
+        Map<Long, BusinessUnitInternal> franchiseMap = returnCommandMap.values().stream()
+                .map(command -> franchiseServiceImpl.getById(command.franchiseId()))
+                .collect(Collectors.toMap(
+                        BusinessUnitInternal::id,
+                        info -> info,
+                        (existing, replacement) -> existing
+                ));
+
+        return returnCommandMap.values().stream()
+                .map(returnInfo -> {
+                    BusinessUnitInternal franchiseInfo = franchiseMap.get(returnInfo.franchiseId());
+
+                    return UnassignedReturnResponse.from(returnInfo, franchiseInfo);
+                })
+                .collect(Collectors.toList());
+    }
 }

--- a/module-core/src/main/java/com/chaing/core/enums/LogType.java
+++ b/module-core/src/main/java/com/chaing/core/enums/LogType.java
@@ -3,18 +3,19 @@ package com.chaing.core.enums;
 public enum LogType {
     INBOUND,
     OUTBOUND,
-    RETURN_OUTBOUND,  // 반품출고
-    RETURN_INBOUND,   // 반품입고
+    RETURN_OUTBOUND,  // 반품 출고
+    RETURN_INBOUND,   // 반품 입고
     SALE,             // 판매
     REFUND,            // 환불
     DISPOSAL,           // 폐기
     SHIPPING,         // 배송중
+    SHIPPED,          // 배송 완료
 
     PICKING,            // 피킹
-    PICKING_WAIT,       // 피킹대기
-    INBOUND_WAIT,       // 입고대기
+    PICKING_WAIT,       // 피킹 대기
+    INBOUND_WAIT,       // 입고 대기
 
     AVAILABLE,      // 가용
-    RETURN_WAIT,    // 반품대기
+    RETURN_WAIT,    // 반품 대기
     EXPIRED         // 유통기한 만료
 }

--- a/module-domain/domain-returns/src/main/java/com/chaing/domain/returns/dto/command/FranchiseReturnCommandForTransit.java
+++ b/module-domain/domain-returns/src/main/java/com/chaing/domain/returns/dto/command/FranchiseReturnCommandForTransit.java
@@ -1,0 +1,15 @@
+package com.chaing.domain.returns.dto.command;
+
+public record FranchiseReturnCommandForTransit(
+        Long franchiseOrderId,
+        String returnCode,
+        Long franchiseId
+) {
+    public static FranchiseReturnCommandForTransit from(Long franchiseOrderId, String returnCode, Long franchiseId) {
+        return new FranchiseReturnCommandForTransit(
+                franchiseOrderId,
+                returnCode,
+                franchiseId
+        );
+    }
+}

--- a/module-domain/domain-returns/src/main/java/com/chaing/domain/returns/repository/FranchiseReturnRepository.java
+++ b/module-domain/domain-returns/src/main/java/com/chaing/domain/returns/repository/FranchiseReturnRepository.java
@@ -34,5 +34,5 @@ public interface FranchiseReturnRepository extends JpaRepository<Returns, Long> 
 
     List<Returns> findAllByFranchiseIdAndDeletedAtIsNull(Long franchiseId);
 
-    List<Returns> findAllByReturnIdIn(List<Long> returnIds);
+    List<Returns> findAllByReturnIdInAndDeletedAtIsNull(List<Long> returnIds);
 }

--- a/module-domain/domain-returns/src/main/java/com/chaing/domain/returns/repository/FranchiseReturnRepository.java
+++ b/module-domain/domain-returns/src/main/java/com/chaing/domain/returns/repository/FranchiseReturnRepository.java
@@ -33,4 +33,6 @@ public interface FranchiseReturnRepository extends JpaRepository<Returns, Long> 
     Optional<Returns> findByReturnIdAndDeletedAtIsNull(Long returnId);
 
     List<Returns> findAllByFranchiseIdAndDeletedAtIsNull(Long franchiseId);
+
+    List<Returns> findAllByReturnIdIn(List<Long> returnIds);
 }

--- a/module-domain/domain-returns/src/main/java/com/chaing/domain/returns/service/FranchiseReturnService.java
+++ b/module-domain/domain-returns/src/main/java/com/chaing/domain/returns/service/FranchiseReturnService.java
@@ -23,6 +23,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -442,6 +443,7 @@ public class FranchiseReturnService {
                 ));
     }
 
+    @Transactional
     public List<FranchiseReturnCommandForTransit> getReturnForTransit(@NotNull(message = "주문을 선택해주세요") List<Long> returnIds) {
 
         if(returnIds == null || returnIds.isEmpty()) {

--- a/module-domain/domain-returns/src/main/java/com/chaing/domain/returns/service/FranchiseReturnService.java
+++ b/module-domain/domain-returns/src/main/java/com/chaing/domain/returns/service/FranchiseReturnService.java
@@ -2,6 +2,7 @@ package com.chaing.domain.returns.service;
 
 import com.chaing.core.dto.command.FranchiseInventoryCommand;
 import com.chaing.core.enums.ReturnItemStatus;
+import com.chaing.domain.returns.dto.command.FranchiseReturnCommandForTransit;
 import com.chaing.domain.returns.dto.command.HQReturnCommand;
 import com.chaing.domain.returns.dto.command.HQReturnDetailCommand;
 import com.chaing.domain.returns.dto.command.ReturnCommand;
@@ -18,6 +19,7 @@ import com.chaing.domain.returns.exception.FranchiseReturnException;
 import com.chaing.domain.returns.repository.FranchiseReturnItemRepository;
 import com.chaing.domain.returns.repository.FranchiseReturnRepository;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -438,5 +440,16 @@ public class FranchiseReturnService {
                         Returns::getReturnId,
                         ReturnCommand::from
                 ));
+    }
+
+    public List<FranchiseReturnCommandForTransit> getReturnForTransit(@NotNull(message = "주문을 선택해주세요") List<Long> returnIds) {
+        List<Returns> selectedReturns = franchiseReturnRepository.findAllByReturnIdIn(returnIds);
+
+        return selectedReturns.stream()
+                .map(selectedReturn -> FranchiseReturnCommandForTransit.from(
+                        selectedReturn.getFranchiseOrderId(),
+                        selectedReturn.getReturnCode(),
+                        selectedReturn.getFranchiseId()
+                )).toList();
     }
 }

--- a/module-domain/domain-returns/src/main/java/com/chaing/domain/returns/service/FranchiseReturnService.java
+++ b/module-domain/domain-returns/src/main/java/com/chaing/domain/returns/service/FranchiseReturnService.java
@@ -443,7 +443,20 @@ public class FranchiseReturnService {
     }
 
     public List<FranchiseReturnCommandForTransit> getReturnForTransit(@NotNull(message = "주문을 선택해주세요") List<Long> returnIds) {
+
+        if(returnIds == null || returnIds.isEmpty()) {
+            throw new FranchiseReturnException(FranchiseReturnErrorCode.DATA_OMISSION);
+        }
+
         List<Returns> selectedReturns = franchiseReturnRepository.findAllByReturnIdInAndDeletedAtIsNull(returnIds);
+
+        Set<Long> foundIds = selectedReturns.stream()
+                .map(Returns::getReturnId)
+                .collect(Collectors.toSet());
+
+        if(!foundIds.containsAll(returnIds)) {
+            throw new FranchiseReturnException(FranchiseReturnErrorCode.DATA_OMISSION);
+        }
 
         return selectedReturns.stream()
                 .map(selectedReturn -> FranchiseReturnCommandForTransit.from(

--- a/module-domain/domain-returns/src/main/java/com/chaing/domain/returns/service/FranchiseReturnService.java
+++ b/module-domain/domain-returns/src/main/java/com/chaing/domain/returns/service/FranchiseReturnService.java
@@ -443,7 +443,7 @@ public class FranchiseReturnService {
     }
 
     public List<FranchiseReturnCommandForTransit> getReturnForTransit(@NotNull(message = "주문을 선택해주세요") List<Long> returnIds) {
-        List<Returns> selectedReturns = franchiseReturnRepository.findAllByReturnIdIn(returnIds);
+        List<Returns> selectedReturns = franchiseReturnRepository.findAllByReturnIdInAndDeletedAtIsNull(returnIds);
 
         return selectedReturns.stream()
                 .map(selectedReturn -> FranchiseReturnCommandForTransit.from(

--- a/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/dto/response/AvailableVehicleInfo.java
+++ b/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/dto/response/AvailableVehicleInfo.java
@@ -3,17 +3,23 @@ package com.chaing.domain.transports.dto.response;
 import com.chaing.domain.transports.entity.Vehicle;
 
 public record AvailableVehicleInfo(
-        Long vehicleId,
-        String vehicleNumber, // 차량 번호
-        Long maxLoad,       // 최대 적재량
-        Long currentWeight,    // 현재 실려있는 양 (Transit 합계)
-        Long availableWeight    // 남은
+        String transportName,       // 업체명
+        String driverName,          // 운전자명
+        String driverPhoneNumber,   // 전화번호
+        Long vehicleId,             // 차량 고유 ID
+        String vehicleNumber,       // 차량 번호
+        Long maxLoad,               // 최대 적재량
+        Long currentLoad,           // 현재 적재량
+        Long availableLoad          // 적재 가능 잔여량 (max - current)
 ) {
-    public static AvailableVehicleInfo from(Vehicle vehicle, Long currentWeight) {
+    public static AvailableVehicleInfo from(String transportName, Vehicle vehicle, Long currentWeight) {
         long safeCurrentWeight = currentWeight == null ? 0 : currentWeight;
         long safeMaxLoad = vehicle.getMaxLoad() == null ? 0 : vehicle.getMaxLoad();
 
         return new AvailableVehicleInfo(
+                transportName,
+                vehicle.getDriverName(),
+                vehicle.getDriverPhone(),
                 vehicle.getVehicleId(),
                 vehicle.getVehicleNumber(),
                 safeMaxLoad,

--- a/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/entity/Transit.java
+++ b/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/entity/Transit.java
@@ -33,6 +33,9 @@ public class Transit extends BaseEntity {
     @Column(nullable = false)
     private String orderCode;
 
+    // 반품 코드(반품 시만)
+    private String returnCode;
+
     // 차량 정보
     @NotNull
     @Column(nullable = false)
@@ -58,9 +61,10 @@ public class Transit extends BaseEntity {
     @Column(nullable = false)
     private Long franchiseId;
 
-    public static Transit create(Long vehicleId, String orderCode, Long weight, String trackingNumber, Long franchiseId) {
+    public static Transit create(Long vehicleId, String orderCode, Long weight, String trackingNumber, Long franchiseId, String returnCode) {
         return Transit.builder()
                 .orderCode(orderCode)
+                .returnCode(returnCode)
                 .vehicleId(vehicleId)
                 .status(DeliverStatus.PENDING)
                 .trackingNumber(trackingNumber)

--- a/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/enums/DeliverStatus.java
+++ b/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/enums/DeliverStatus.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 public enum DeliverStatus {
 
     PENDING("배송 대기"),
-    IN_TRANSIT("배송 중"),
+    IN_TRANSIT("배송중"),
     DELIVERED("배송 완료");
 
     private final String description;

--- a/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/repository/TransportRepository.java
+++ b/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/repository/TransportRepository.java
@@ -15,4 +15,7 @@ public interface TransportRepository extends JpaRepository<Transport, Long> {
 
     @Query("select t.unitPrice from Transport t where t.transportId = :transportId")
     Long findUnitPriceByTransportId(@Param("transportId") Long transportId);
+
+    @Query("select t.companyName from Transport t where t.transportId = :transportId")
+    String findCompanyNameByTransportId(@Param("transportId") Long transportId);
 }

--- a/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/repository/VehicleRepository.java
+++ b/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/repository/VehicleRepository.java
@@ -13,7 +13,6 @@ import java.util.List;
 
 @Repository
 public interface VehicleRepository extends JpaRepository<Vehicle, Long> {
-
     List<Vehicle> findAllByStatusAndDispatchable(UsableStatus status, Dispatchable dispatchable);
 
     @Query("SELECT v.maxLoad FROM Vehicle v WHERE v.vehicleId = :vehicleId")
@@ -42,4 +41,7 @@ public interface VehicleRepository extends JpaRepository<Vehicle, Long> {
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Vehicle v SET v.dispatchable = 'DISPATCHED' where v.vehicleId = :vehicleId")
     void updateDispatchable(@Param("vehicleId") Long vehicleId);
+
+    @Query("SELECT v FROM Vehicle v WHERE v.dispatchable in (:available, :dispatched)")
+    List<Vehicle> findAllByDispatchable(@Param("available") Dispatchable available, @Param("dispatched") Dispatchable dispatched);
 }

--- a/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/repository/VehicleRepository.java
+++ b/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/repository/VehicleRepository.java
@@ -38,4 +38,8 @@ public interface VehicleRepository extends JpaRepository<Vehicle, Long> {
 
     @Query("SELECT v.transportId FROM Vehicle v WHERE v.vehicleId = :vehicleId")
     Long findTransportIdByVehicleId(Long vehicleId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Vehicle v SET v.dispatchable = 'DISPATCHED' where v.vehicleId = :vehicleId")
+    void updateDispatchable(@Param("vehicleId") Long vehicleId);
 }

--- a/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/repository/VehicleRepository.java
+++ b/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/repository/VehicleRepository.java
@@ -39,7 +39,10 @@ public interface VehicleRepository extends JpaRepository<Vehicle, Long> {
     Long findTransportIdByVehicleId(Long vehicleId);
 
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE Vehicle v SET v.dispatchable = 'DISPATCHED' where v.vehicleId = :vehicleId")
+    @Query("UPDATE Vehicle v SET " +
+            "v.updatedAt = CURRENT_TIMESTAMP, " +
+            "v.dispatchable = com.chaing.domain.transports.enums.Dispatchable.DISPATCHED " +
+            "WHERE v.vehicleId = :vehicleId AND v.deletedAt IS NULL")
     void updateDispatchable(@Param("vehicleId") Long vehicleId);
 
     @Query("SELECT v FROM Vehicle v WHERE v.dispatchable in (:available, :dispatched)")

--- a/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/service/InternalTransportService.java
+++ b/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/service/InternalTransportService.java
@@ -71,6 +71,11 @@ public class InternalTransportService {
 
         // 차량 배정
         executor.createTransits(vehicleId, orders, trackingMap);
+
+        // 차량 상태 확인 및 변경
+        if(maxLoad < currentWeight + newWeight + 100) {
+            executor.updateDispatchableStatus(vehicleId);
+        }
     }
 
     @Transactional

--- a/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/service/InternalTransportService.java
+++ b/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/service/InternalTransportService.java
@@ -44,7 +44,8 @@ public class InternalTransportService {
                 })
                 .map(vehicle -> {
                     Long currentWeight = reader.getCurrentTransitWeight(vehicle.getVehicleId());
-                    return AvailableVehicleInfo.from(vehicle, currentWeight);
+                    String transportName = reader.getTransportName(vehicle.getTransportId());
+                    return AvailableVehicleInfo.from(transportName, vehicle, currentWeight);
                 })
                 .toList();
     }
@@ -103,5 +104,16 @@ public class InternalTransportService {
         return franchiseList.stream()
                 .map(franchiseId -> new DeliveryFeeInfo(franchiseId, deliveryFee))
                 .toList();
+    }
+
+    public List<AvailableVehicleInfo> getAllAvailableVehicle() {
+        List <Vehicle> vehicleList = reader.getAllAvailableVehicles();
+
+        return vehicleList.stream()
+                .map(vehicle -> {
+                    Long currentWeight = reader.getCurrentTransitWeight(vehicle.getVehicleId());
+                    String transportName = reader.getTransportName(vehicle.getTransportId());
+                    return AvailableVehicleInfo.from(transportName, vehicle, currentWeight);
+                }).toList();
     }
 }

--- a/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/service/InternalTransportService.java
+++ b/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/service/InternalTransportService.java
@@ -71,7 +71,7 @@ public class InternalTransportService {
         validator.checkTrackingNumber(orders, trackingMap);
 
         // 차량 배정
-        executor.createTransits(vehicleId, orders, trackingMap);
+        executor.createTransits(vehicleId, orders, trackingMap, null);
 
         // 차량 상태 확인 및 변경
         if(maxLoad < currentWeight + newWeight + 100) {
@@ -115,5 +115,16 @@ public class InternalTransportService {
                     String transportName = reader.getTransportName(vehicle.getTransportId());
                     return AvailableVehicleInfo.from(transportName, vehicle, currentWeight);
                 }).toList();
+    }
+
+    public void assignVehicleReturn(@NotNull(message = "차량을 선택해주세요") Long vehicleId,
+                                    List<OrderInfo> orderInfos, Map<String, String> trackingMap,
+                                    Long totalWeight, List<String> returnCodes) {
+
+        // 송장 유효성 검증
+        validator.checkTrackingNumber(orderInfos, trackingMap);
+
+        // 차량 배정
+        executor.createTransits(vehicleId, orderInfos, trackingMap, returnCodes);
     }
 }

--- a/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/service/InternalTransportService.java
+++ b/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/service/InternalTransportService.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -58,6 +59,8 @@ public class InternalTransportService {
             Map<String, String> trackingMap,
             Long newWeight) {
 
+        List<String> orderCase = List.of();
+
         // 최대 적재량 조회
         Long maxLoad = reader.getVehicleMaxLoad(vehicleId);
 
@@ -71,7 +74,7 @@ public class InternalTransportService {
         validator.checkTrackingNumber(orders, trackingMap);
 
         // 차량 배정
-        executor.createTransits(vehicleId, orders, trackingMap, null);
+        executor.createTransits(vehicleId, orders, trackingMap, orderCase);
 
         // 차량 상태 확인 및 변경
         if(maxLoad < currentWeight + newWeight + 100) {

--- a/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/usecase/executor/TransportExecutor.java
+++ b/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/usecase/executor/TransportExecutor.java
@@ -10,4 +10,6 @@ public interface TransportExecutor {
     void createTransits(@NotNull(message = "차량을 선택해주세요") Long vehicleId, List<OrderInfo> orders, Map<String, String> trackingMap);
 
     String cancelTransit(Long transportId);
+
+    void updateDispatchableStatus(Long vehicleId);
 }

--- a/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/usecase/executor/TransportExecutor.java
+++ b/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/usecase/executor/TransportExecutor.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 public interface TransportExecutor {
-    void createTransits(@NotNull(message = "차량을 선택해주세요") Long vehicleId, List<OrderInfo> orders, Map<String, String> trackingMap);
+    void createTransits(@NotNull(message = "차량을 선택해주세요") Long vehicleId, List<OrderInfo> orders, Map<String, String> trackingMap, List<String> returnCodes);
 
     String cancelTransit(Long transportId);
 

--- a/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/usecase/executor/TransportExecutorImpl.java
+++ b/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/usecase/executor/TransportExecutorImpl.java
@@ -20,16 +20,19 @@ public class TransportExecutorImpl implements TransportExecutor {
     private final VehicleRepository vehicleRepository;
 
     @Override
-    public void createTransits(Long vehicleId, List<OrderInfo> orders, Map<String, String> trackingMap) {
+    public void createTransits(Long vehicleId, List<OrderInfo> orders, Map<String, String> trackingMap, List<String> returnCodes) {
 
         List<Transit> transits = orders.stream()
-                .map(order -> Transit.create(
+                .flatMap(order -> returnCodes.stream()
+                .map(code -> Transit.create(
                         vehicleId,
                         order.orderCode(),
                         order.weight(),
                         trackingMap.get(order.orderCode()),
-                        order.franchiseId()
+                        order.franchiseId(),
+                        code
                 ))
+                )
                 .toList();
 
         transitRepository.saveAll(transits);

--- a/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/usecase/executor/TransportExecutorImpl.java
+++ b/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/usecase/executor/TransportExecutorImpl.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 @Component
 @RequiredArgsConstructor
@@ -23,16 +24,22 @@ public class TransportExecutorImpl implements TransportExecutor {
     public void createTransits(Long vehicleId, List<OrderInfo> orders, Map<String, String> trackingMap, List<String> returnCodes) {
 
         List<Transit> transits = orders.stream()
-                .flatMap(order -> returnCodes.stream()
-                .map(code -> Transit.create(
-                        vehicleId,
-                        order.orderCode(),
-                        order.weight(),
-                        trackingMap.get(order.orderCode()),
-                        order.franchiseId(),
-                        code
-                ))
-                )
+                .flatMap(order -> {
+                    if (returnCodes == null || returnCodes.isEmpty()) {
+                        return Stream.of(Transit.create(
+                                vehicleId, order.orderCode(), order.weight(),
+                                trackingMap.get(order.orderCode()), order.franchiseId(),
+                                ""
+                        ));
+                    }
+
+                    return returnCodes.stream()
+                            .map(code -> Transit.create(
+                                    vehicleId, order.orderCode(), order.weight(),
+                                    trackingMap.get(order.orderCode()), order.franchiseId(),
+                                    code
+                            ));
+                })
                 .toList();
 
         transitRepository.saveAll(transits);

--- a/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/usecase/executor/TransportExecutorImpl.java
+++ b/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/usecase/executor/TransportExecutorImpl.java
@@ -46,4 +46,9 @@ public class TransportExecutorImpl implements TransportExecutor {
 
         return orderCode;
     }
+
+    @Override
+    public void updateDispatchableStatus(Long vehicleId) {
+        vehicleRepository.updateDispatchable(vehicleId);
+    }
 }

--- a/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/usecase/executor/TransportExecutorImpl.java
+++ b/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/usecase/executor/TransportExecutorImpl.java
@@ -5,6 +5,7 @@ import com.chaing.domain.transports.entity.Transit;
 import com.chaing.domain.transports.exception.TransportErrorCode;
 import com.chaing.domain.transports.exception.TransportException;
 import com.chaing.domain.transports.repository.TransitRepository;
+import com.chaing.domain.transports.repository.VehicleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -16,6 +17,7 @@ import java.util.Map;
 public class TransportExecutorImpl implements TransportExecutor {
 
     private final TransitRepository transitRepository;
+    private final VehicleRepository vehicleRepository;
 
     @Override
     public void createTransits(Long vehicleId, List<OrderInfo> orders, Map<String, String> trackingMap) {

--- a/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/usecase/reader/TransportReader.java
+++ b/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/usecase/reader/TransportReader.java
@@ -1,7 +1,5 @@
 package com.chaing.domain.transports.usecase.reader;
 
-import com.chaing.domain.transports.dto.OrderInfo;
-import com.chaing.domain.transports.entity.Transit;
 import com.chaing.domain.transports.entity.Vehicle;
 import com.chaing.domain.transports.enums.DeliverStatus;
 import jakarta.validation.constraints.NotNull;
@@ -19,4 +17,8 @@ public interface TransportReader {
     DeliverStatus getTransitStatus(Long transportId);
 
     Long getDeliveryFee(@NotNull(message = "차량을 선택해주세요") Long vehicleId);
+
+    String getTransportName(Long transportId);
+
+    List<Vehicle> getAllAvailableVehicles();
 }

--- a/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/usecase/reader/TransportReaderImpl.java
+++ b/module-domain/domain-transports/src/main/java/com/chaing/domain/transports/usecase/reader/TransportReaderImpl.java
@@ -66,4 +66,18 @@ public class TransportReaderImpl implements TransportReader {
 
         return unitPrice;
     }
+
+    @Override
+    public String getTransportName(Long transportId) {
+        String transportName = transportRepository.findCompanyNameByTransportId(transportId);
+        if(transportName == null) {
+            throw new TransportException(TransportErrorCode.TRANSPORT_VENDOR_NOT_FOUND);
+        }
+        return transportName;
+    }
+
+    @Override
+    public List<Vehicle> getAllAvailableVehicles() {
+        return vehicleRepository.findAllByDispatchable(Dispatchable.DISPATCHED, Dispatchable.AVAILABLE);
+    }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
> 이슈 번호를 작성해주세요. (예: Closes #123)
- Closes #160 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- [x] 운행 가능 차량 리스트 조회 연동
- [x] 차량 미배정 반품 목록 조회 연동
- [x] 반품 차량 배정 로직 연동

## ✅ 테스트 결과
> 수행한 테스트와 결과를 요약해주세요. (예: 단위 테스트 전체 통과)
- [ ] 단위 테스트 (JUnit)
- [ ] 통합 테스트
- [ ] 
---
### ✅ 변경 사항 체크리스트
- [ ] 커밋 메시지 컨벤션을 준수했나요?
- [ ] 불필요한 공백이나 주석을 제거했나요?
- [ ] 코드에 영향이 있는 부분에 대해 테스트를 작성했나요?
- [ ] 모든 테스트가 성공했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 반품 수송 전용 기능 추가: 반품용 차량 목록 조회, 미할당 반품 목록 조회, 반품 차량 배정
  * 차량 정보 표시 항목 확대: 운송사명, 기사명, 기사 연락처 노출

* **개선 사항**
  * 차량 배정 흐름 강화(반품 포함) 및 선택 항목 검증 강화
  * 배정 후 차량 상태 자동 갱신 처리 추가

* **기타**
  * 로그/상태 표기 값 및(enum) 일부 표기 보완
<!-- end of auto-generated comment: release notes by coderabbit.ai -->