### PR TITLE
[feat] 판매 목록 조회 api 구현

### DIFF
--- a/module-app/app-api/src/main/java/com/chaing/api/controller/franchise/FranchiseInventoryController.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/controller/franchise/FranchiseInventoryController.java
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -148,7 +149,9 @@ public class FranchiseInventoryController {
         @Operation(summary = "판매 제품 목록 조회", description = "스캔된 판매 목록이 화면에 출력된다.")
         @GetMapping("/scanned-sales-list")
         public ResponseEntity<ApiResponse<ScannedForSaleResponse>> getScannedSalesList(
-                @RequestParam List<@NotBlank String> serialCodes,
+                @RequestParam
+                @NotEmpty(message = "선택된 제품이 존재하지 않습니다.")
+                List<@NotBlank String> serialCodes,
                 @AuthenticationPrincipal UserPrincipal Principal
         ) {
             return ResponseEntity.ok(ApiResponse.success(franchiseInventoryFacade.getFranchiseItemsForSale(serialCodes, Principal.getBusinessUnitId())));

--- a/module-app/app-api/src/main/java/com/chaing/api/controller/franchise/FranchiseInventoryController.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/controller/franchise/FranchiseInventoryController.java
@@ -1,5 +1,8 @@
 package com.chaing.api.controller.franchise;
 
+import com.chaing.api.dto.franchise.sales.request.SaleScanItemRequest;
+import com.chaing.api.dto.franchise.sales.response.ScannedForSaleResponse;
+import com.chaing.api.dto.franchise.sales.response.ScannedItemForSaleResponse;
 import com.chaing.api.facade.franchise.FranchiseInventoryFacade;
 import com.chaing.api.security.principal.UserPrincipal;
 import com.chaing.core.dto.ApiResponse;
@@ -15,11 +18,13 @@ import com.chaing.domain.inventories.dto.request.DisposalRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,6 +34,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.security.Principal;
 import java.util.List;
 import java.util.Map;
 
@@ -137,5 +143,14 @@ public class FranchiseInventoryController {
                 return ResponseEntity.ok(ApiResponse.success(
                                 franchiseInventoryFacade.verifyAdminPassword(principal.getId(),
                                                 request.get("password"))));
+        }
+
+        @Operation(summary = "판매 제품 목록 조회", description = "스캔된 판매 목록이 화면에 출력된다.")
+        @GetMapping("/scanned-sales-list")
+        public ResponseEntity<ApiResponse<ScannedForSaleResponse>> getScannedSalesList(
+                @RequestParam List<@NotBlank String> serialCodes,
+                @AuthenticationPrincipal UserPrincipal Principal
+        ) {
+            return ResponseEntity.ok(ApiResponse.success(franchiseInventoryFacade.getFranchiseItemsForSale(serialCodes, Principal.getBusinessUnitId())));
         }
 }

--- a/module-app/app-api/src/main/java/com/chaing/api/dto/franchise/sales/request/SaleScanItemRequest.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/dto/franchise/sales/request/SaleScanItemRequest.java
@@ -1,0 +1,12 @@
+package com.chaing.api.dto.franchise.sales.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record SaleScanItemRequest(
+        @NotEmpty(message = "선택된 제품이 존재하지 않습니다.")
+        List<@NotBlank String> serialCodes
+) {
+}

--- a/module-app/app-api/src/main/java/com/chaing/api/dto/franchise/sales/response/ScannedForSaleResponse.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/dto/franchise/sales/response/ScannedForSaleResponse.java
@@ -1,0 +1,47 @@
+package com.chaing.api.dto.franchise.sales.response;
+
+import com.chaing.core.dto.info.ProductInfo;
+import com.chaing.domain.inventories.dto.request.InventoryRequest;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+public record ScannedForSaleResponse(
+        @NotNull
+        Integer totalQuantity,
+
+        @NotNull
+        @Min(1)
+        BigDecimal totalAmount,
+
+        @NotNull
+        List<ScannedItemForSaleResponse> requestList
+) {
+    public static ScannedForSaleResponse create(List<InventoryRequest> scannedItems, Map<Long, ProductInfo> productInfos){
+
+        // 개별 상품 리스트
+        List<ScannedItemForSaleResponse> requestList = scannedItems.stream()
+                .map(item -> {
+                    ProductInfo info = productInfos.get(item.productId());
+                    return ScannedItemForSaleResponse.create(
+                            item.productId(),
+                            info.productCode(),
+                            info.productName(),
+                            info.retailPrice(),
+                            item.serialCode()
+                    );
+                })
+                .toList();
+
+        int totalQuantity = requestList.size();
+
+        BigDecimal totalAmount = requestList.stream()
+                .map(ScannedItemForSaleResponse::unitPrice)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        return new ScannedForSaleResponse(totalQuantity, totalAmount, requestList);
+    }
+}

--- a/module-app/app-api/src/main/java/com/chaing/api/dto/franchise/sales/response/ScannedForSaleResponse.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/dto/franchise/sales/response/ScannedForSaleResponse.java
@@ -2,6 +2,8 @@ package com.chaing.api.dto.franchise.sales.response;
 
 import com.chaing.core.dto.info.ProductInfo;
 import com.chaing.domain.inventories.dto.request.InventoryRequest;
+import com.chaing.domain.inventories.exception.InventoriesErrorCode;
+import com.chaing.domain.inventories.exception.InventoriesException;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
@@ -26,6 +28,9 @@ public record ScannedForSaleResponse(
         List<ScannedItemForSaleResponse> requestList = scannedItems.stream()
                 .map(item -> {
                     ProductInfo info = productInfos.get(item.productId());
+                    if(info == null) {
+                        throw new InventoriesException(InventoriesErrorCode.PRODUCT_NOT_FOUND);
+                    }
                     return ScannedItemForSaleResponse.create(
                             item.productId(),
                             info.productCode(),

--- a/module-app/app-api/src/main/java/com/chaing/api/dto/franchise/sales/response/ScannedItemForSaleResponse.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/dto/franchise/sales/response/ScannedItemForSaleResponse.java
@@ -1,0 +1,29 @@
+package com.chaing.api.dto.franchise.sales.response;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+
+public record ScannedItemForSaleResponse(
+        @NotNull
+        Long productId,
+
+        @NotBlank
+        String productCode,
+
+        @NotBlank
+        String productName,
+
+        @NotNull
+        BigDecimal unitPrice,
+
+        @NotBlank
+        String serialCode
+) {
+    public static ScannedItemForSaleResponse create(
+            Long productId, String productCode, String productName, BigDecimal unitPrice, String serialCode
+    ){
+        return new ScannedItemForSaleResponse(productId, productCode, productName, unitPrice, serialCode);
+    }
+}

--- a/module-app/app-api/src/main/java/com/chaing/api/dto/outbound/request/OutboundConfirmRequest.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/dto/outbound/request/OutboundConfirmRequest.java
@@ -1,4 +1,0 @@
-package com.chaing.api.dto.outbound.request;
-
-public record OutboundConfirmRequest() {
-}

--- a/module-app/app-api/src/main/java/com/chaing/api/dto/outbound/request/OutboundPickingRequest.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/dto/outbound/request/OutboundPickingRequest.java
@@ -1,4 +1,0 @@
-package com.chaing.api.dto.outbound.request;
-
-public record OutboundPickingRequest() {
-}

--- a/module-app/app-api/src/main/java/com/chaing/api/dto/outbound/request/OutboundReadyRequest.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/dto/outbound/request/OutboundReadyRequest.java
@@ -1,4 +1,0 @@
-package com.chaing.api.dto.outbound.request;
-
-public record OutboundReadyRequest() {
-}

--- a/module-app/app-api/src/main/java/com/chaing/api/facade/franchise/FranchiseInventoryFacade.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/facade/franchise/FranchiseInventoryFacade.java
@@ -441,7 +441,7 @@ public class FranchiseInventoryFacade {
 
     public ScannedForSaleResponse getFranchiseItemsForSale(@NotEmpty(message = "선택된 제품이 존재하지 않습니다.") List<String> serialCodes, Long franchiseId) {
 
-        List<InventoryRequest> scannedItems = inventoryService.getItemBySerialCode(serialCodes);
+        List<InventoryRequest> scannedItems = inventoryService.getItemBySerialCode(serialCodes, franchiseId);
 
         Map<Long, ProductInfo> productInfos = productService.getProductInfos(
                 scannedItems.stream().map(InventoryRequest::productId).distinct().toList());

--- a/module-app/app-api/src/main/java/com/chaing/api/facade/franchise/FranchiseInventoryFacade.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/facade/franchise/FranchiseInventoryFacade.java
@@ -1,5 +1,7 @@
 package com.chaing.api.facade.franchise;
 
+import com.chaing.api.dto.franchise.sales.response.ScannedForSaleResponse;
+import com.chaing.api.dto.franchise.sales.response.ScannedItemForSaleResponse;
 import com.chaing.core.dto.info.ProductInfo;
 import com.chaing.core.enums.LogType;
 import com.chaing.domain.inventories.dto.request.DisposalRequest;
@@ -30,6 +32,8 @@ import com.chaing.domain.users.service.UserManagementService;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
@@ -391,5 +395,15 @@ public class FranchiseInventoryFacade {
             redisTemplate.opsForValue().set(key, objectMapper.writeValueAsString(payload), CACHE_TTL);
         } catch (Exception ignored) {
         }
+    }
+
+    public ScannedForSaleResponse getFranchiseItemsForSale(@NotEmpty(message = "선택된 제품이 존재하지 않습니다.") List<String> serialCodes, Long franchiseId) {
+
+        List<InventoryRequest> scannedItems = inventoryService.getItemBySerialCode(serialCodes);
+
+        Map<Long, ProductInfo> productInfos = productService.getProductInfos(
+                scannedItems.stream().map(InventoryRequest::productId).distinct().toList());
+
+        return ScannedForSaleResponse.create(scannedItems, productInfos);
     }
 }

--- a/module-domain/domain-inventories/src/main/java/com/chaing/domain/inventories/repository/FranchiseInventoryRepository.java
+++ b/module-domain/domain-inventories/src/main/java/com/chaing/domain/inventories/repository/FranchiseInventoryRepository.java
@@ -38,6 +38,9 @@ public interface FranchiseInventoryRepository extends JpaRepository<FranchiseInv
     List<FranchiseInventory> findByInventoryIdInAndFranchiseId(List<Long> ids, Long franchiseId);
     List<FranchiseInventory> findByBoxCodeInAndFranchiseId(List<String> boxCodes, Long franchiseId);
 
-    @Query("select fi from FranchiseInventory fi where fi.status = 'AVAILABLE' and fi.serialCode in (:serialCodes) and fi.franchiseId = :franchiseId")
-    List<FranchiseInventory> getAllByStatusAndSerialCodeAndFranchiseId(@Param("serialCodes") @NotEmpty(message = "선택된 제품이 존재하지 않습니다.") List<String> serialCodes, @Param("franchiseId") Long franchiseId);
+    @Query("select fi from FranchiseInventory fi where fi.status = :status and fi.serialCode in (:serialCodes) and fi.franchiseId = :franchiseId")
+    List<FranchiseInventory> getAllByStatusAndSerialCodeAndFranchiseId(
+            @Param("serialCodes") @NotEmpty(message = "선택된 제품이 존재하지 않습니다.") List<String> serialCodes,
+            @Param("franchiseId") Long franchiseId,
+            @Param("status") LogType status);
 }

--- a/module-domain/domain-inventories/src/main/java/com/chaing/domain/inventories/repository/FranchiseInventoryRepository.java
+++ b/module-domain/domain-inventories/src/main/java/com/chaing/domain/inventories/repository/FranchiseInventoryRepository.java
@@ -3,6 +3,7 @@ package com.chaing.domain.inventories.repository;
 import com.chaing.core.enums.LogType;
 import com.chaing.domain.inventories.entity.FranchiseInventory;
 import com.chaing.domain.inventories.repository.interfaces.FranchiseInventoryRepositoryCustom;
+import jakarta.validation.constraints.NotEmpty;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -36,4 +37,7 @@ public interface FranchiseInventoryRepository extends JpaRepository<FranchiseInv
     List<FranchiseInventory> findByInventoryIdIn(List<Long> ids);
     List<FranchiseInventory> findByInventoryIdInAndFranchiseId(List<Long> ids, Long franchiseId);
     List<FranchiseInventory> findByBoxCodeInAndFranchiseId(List<String> boxCodes, Long franchiseId);
+
+    @Query("select fi from FranchiseInventory fi where fi.status = 'AVAILABLE' and fi.serialCode in (:serialCodes)")
+    List<FranchiseInventory> getAllByStatusAndSerialCode(@Param("serialCodes") @NotEmpty(message = "선택된 제품이 존재하지 않습니다.") List<String> serialCodes);
 }

--- a/module-domain/domain-inventories/src/main/java/com/chaing/domain/inventories/repository/FranchiseInventoryRepository.java
+++ b/module-domain/domain-inventories/src/main/java/com/chaing/domain/inventories/repository/FranchiseInventoryRepository.java
@@ -38,6 +38,6 @@ public interface FranchiseInventoryRepository extends JpaRepository<FranchiseInv
     List<FranchiseInventory> findByInventoryIdInAndFranchiseId(List<Long> ids, Long franchiseId);
     List<FranchiseInventory> findByBoxCodeInAndFranchiseId(List<String> boxCodes, Long franchiseId);
 
-    @Query("select fi from FranchiseInventory fi where fi.status = 'AVAILABLE' and fi.serialCode in (:serialCodes)")
-    List<FranchiseInventory> getAllByStatusAndSerialCode(@Param("serialCodes") @NotEmpty(message = "선택된 제품이 존재하지 않습니다.") List<String> serialCodes);
+    @Query("select fi from FranchiseInventory fi where fi.status = 'AVAILABLE' and fi.serialCode in (:serialCodes) and fi.franchiseId = :franchiseId")
+    List<FranchiseInventory> getAllByStatusAndSerialCodeAndFranchiseId(@Param("serialCodes") @NotEmpty(message = "선택된 제품이 존재하지 않습니다.") List<String> serialCodes, @Param("franchiseId") Long franchiseId);
 }

--- a/module-domain/domain-inventories/src/main/java/com/chaing/domain/inventories/service/InventoryService.java
+++ b/module-domain/domain-inventories/src/main/java/com/chaing/domain/inventories/service/InventoryService.java
@@ -9,6 +9,7 @@ import com.chaing.domain.inventories.dto.request.DisposalRequest;
 import com.chaing.domain.inventories.dto.request.FranchiseInventoryItemsRequest;
 import com.chaing.domain.inventories.dto.request.HQInventoryItemsRequest;
 import com.chaing.domain.inventories.dto.request.InventoryBatchRequest;
+import com.chaing.domain.inventories.dto.request.InventoryRequest;
 import com.chaing.domain.inventories.dto.request.SafetyStockRequest;
 import com.chaing.domain.inventories.dto.response.ExpirationBatchResultResponse;
 import com.chaing.domain.inventories.dto.response.FranchiseInventoryBatchResponse;
@@ -28,6 +29,7 @@ import com.chaing.domain.inventories.repository.FactoryInventoryRepository;
 import com.chaing.domain.inventories.repository.FranchiseInventoryRepository;
 import com.chaing.domain.inventories.repository.HQInventoryRepository;
 import com.chaing.domain.inventories.repository.InventoryPolicyRepository;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -557,5 +559,31 @@ public class InventoryService {
                 throw new InventoriesException(InventoriesErrorCode.INVALID_STOCK);
             }
         });
+    }
+
+    public List<InventoryRequest> getItemBySerialCode(@NotEmpty(message = "선택된 제품이 존재하지 않습니다.") List<String> serialCodes) {
+
+        List<FranchiseInventory> scannedItems = franchiseInventoryRepository.getAllByStatusAndSerialCode(serialCodes);
+
+        if(scannedItems == null || scannedItems.isEmpty()) {
+            throw new InventoriesException(InventoriesErrorCode.INVENTORIES_IS_NULL);
+        }
+
+        long requestCount = serialCodes.stream().distinct().count();
+        long getCount = scannedItems.stream().distinct().count();
+
+        if(requestCount != getCount) {
+            throw new InventoriesException(InventoriesErrorCode.INVALID_STOCK);
+        }
+
+        return scannedItems.stream()
+                .map(item -> new InventoryRequest(
+                        item.getProductId(),
+                        item.getSerialCode(),
+                        item.getOrderItemId(),
+                        item.getStatus(),
+                        item.getManufactureDate()
+                ))
+                .toList();
     }
 }

--- a/module-domain/domain-inventories/src/main/java/com/chaing/domain/inventories/service/InventoryService.java
+++ b/module-domain/domain-inventories/src/main/java/com/chaing/domain/inventories/service/InventoryService.java
@@ -563,7 +563,7 @@ public class InventoryService {
 
     public List<InventoryRequest> getItemBySerialCode(@NotEmpty(message = "선택된 제품이 존재하지 않습니다.") List<String> serialCodes, Long franchiseId) {
 
-        List<FranchiseInventory> scannedItems = franchiseInventoryRepository.getAllByStatusAndSerialCodeAndFranchiseId(serialCodes, franchiseId);
+        List<FranchiseInventory> scannedItems = franchiseInventoryRepository.getAllByStatusAndSerialCodeAndFranchiseId(serialCodes, franchiseId, LogType.AVAILABLE);
 
         if(scannedItems == null || scannedItems.isEmpty()) {
             throw new InventoriesException(InventoriesErrorCode.INVENTORIES_IS_NULL);

--- a/module-domain/domain-inventories/src/main/java/com/chaing/domain/inventories/service/InventoryService.java
+++ b/module-domain/domain-inventories/src/main/java/com/chaing/domain/inventories/service/InventoryService.java
@@ -561,9 +561,9 @@ public class InventoryService {
         });
     }
 
-    public List<InventoryRequest> getItemBySerialCode(@NotEmpty(message = "선택된 제품이 존재하지 않습니다.") List<String> serialCodes) {
+    public List<InventoryRequest> getItemBySerialCode(@NotEmpty(message = "선택된 제품이 존재하지 않습니다.") List<String> serialCodes, Long franchiseId) {
 
-        List<FranchiseInventory> scannedItems = franchiseInventoryRepository.getAllByStatusAndSerialCode(serialCodes);
+        List<FranchiseInventory> scannedItems = franchiseInventoryRepository.getAllByStatusAndSerialCodeAndFranchiseId(serialCodes, franchiseId);
 
         if(scannedItems == null || scannedItems.isEmpty()) {
             throw new InventoriesException(InventoriesErrorCode.INVENTORIES_IS_NULL);

--- a/module-domain/domain-sales/src/main/java/com/chaing/domain/sales/dto/request/FranchiseSellItemRequest.java
+++ b/module-domain/domain-sales/src/main/java/com/chaing/domain/sales/dto/request/FranchiseSellItemRequest.java
@@ -1,6 +1,5 @@
 package com.chaing.domain.sales.dto.request;
 
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -17,10 +16,6 @@ public record FranchiseSellItemRequest(
 
         @NotBlank
         String productName,
-
-        @NotNull
-        @Min(1)
-        Integer quantity,
 
         @NotNull
         BigDecimal unitPrice,

--- a/module-domain/domain-sales/src/main/java/com/chaing/domain/sales/entity/SalesItem.java
+++ b/module-domain/domain-sales/src/main/java/com/chaing/domain/sales/entity/SalesItem.java
@@ -36,9 +36,6 @@ public class SalesItem extends BaseEntity {
     private Long productId; // fk, 타 도메인이기 때문에 기본키만 가짐
 
     @Column(nullable = false)
-    private Integer quantity;
-
-    @Column(nullable = false)
     private String productCode;    // snapshot
 
     @Column(nullable = false)

--- a/module-domain/domain-sales/src/main/java/com/chaing/domain/sales/service/FranchiseSalesService.java
+++ b/module-domain/domain-sales/src/main/java/com/chaing/domain/sales/service/FranchiseSalesService.java
@@ -87,7 +87,6 @@ public class FranchiseSalesService {
                 salesItem = SalesItem.builder()
                         .sales(sales)
                         .productId(itemRequest.productId())
-                        .quantity(1)
                         .productCode(itemRequest.productCode())
                         .productName(itemRequest.productName())
                         .lot(itemRequest.serialCode())

--- a/module-domain/domain-sales/src/main/java/com/chaing/domain/sales/service/FranchiseSalesService.java
+++ b/module-domain/domain-sales/src/main/java/com/chaing/domain/sales/service/FranchiseSalesService.java
@@ -87,7 +87,7 @@ public class FranchiseSalesService {
                 salesItem = SalesItem.builder()
                         .sales(sales)
                         .productId(itemRequest.productId())
-                        .quantity(itemRequest.quantity())
+                        .quantity(1)
                         .productCode(itemRequest.productCode())
                         .productName(itemRequest.productName())
                         .lot(itemRequest.serialCode())


### PR DESCRIPTION
## 🔗 연관된 이슈
> 이슈 번호를 작성해주세요. (예: Closes #123)
- Closes #172 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- [ ] 스캔된 판매 목록 조회 api

## ✅ 테스트 결과
> 수행한 테스트와 결과를 요약해주세요. (예: 단위 테스트 전체 통과)
- [ ] 단위 테스트 (JUnit)
- [ ] 통합 테스트

---
### ✅ 변경 사항 체크리스트
- [ ] 커밋 메시지 컨벤션을 준수했나요?
- [ ] 불필요한 공백이나 주석을 제거했나요?
- [ ] 코드에 영향이 있는 부분에 대해 테스트를 작성했나요?
- [ ] 모든 테스트가 성공했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 시리얼 코드로 여러 상품을 스캔해 판매용 상품 목록(상품별 정보·총수량·총금액)을 조회하는 신규 엔드포인트 추가.

* **개선**
  * 판매 처리 흐름에서 항목 수량 관련 처리를 단순화하여 흐름을 정리.

* **제거**
  * 사용되지 않는 몇몇 빈 요청 타입과 엔티티 필드(수량) 삭제로 API 표면을 간결화.

* **검증/안정성**
  * 시리얼 코드 목록에 대한 입력 검증을 추가해 잘못된 요청을 사전 차단.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->