### PR TITLE
[fix] #180 salesItem 내 quantity 컬럼 삭제로 인한 오류 해결

### DIFF
--- a/module-app/app-api/src/main/java/com/chaing/api/facade/franchise/FranchiseSettlementFacade.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/facade/franchise/FranchiseSettlementFacade.java
@@ -258,12 +258,12 @@ public class FranchiseSettlementFacade {
                                 .map(entry -> {
                                         String name = entry.getKey();
                                         List<SalesItem> group = entry.getValue();
-                                        int totalQty = group.stream()
-                                                        .mapToInt(SalesItem::getQuantity).sum();
-                                        BigDecimal total = group.stream()
-                                                        .map(item -> item.getUnitPrice().multiply(
-                                                                        BigDecimal.valueOf(item.getQuantity())))
-                                                        .reduce(BigDecimal.ZERO, BigDecimal::add);
+                                    int totalQty = (int) group.stream()
+                                            .distinct()
+                                            .count();
+                                    BigDecimal total = group.stream()
+                                            .map(SalesItem::getUnitPrice)
+                                            .reduce(BigDecimal.ZERO, BigDecimal::add);
                                         BigDecimal displayPrice = group.get(0).getUnitPrice();
                                         return new FranchiseSalesItemResponse(0, name, totalQty, displayPrice, total);
                                 }) // 단가가 변경될 경우

--- a/module-app/app-api/src/main/java/com/chaing/api/facade/franchise/FranchiseSettlementFacade.java
+++ b/module-app/app-api/src/main/java/com/chaing/api/facade/franchise/FranchiseSettlementFacade.java
@@ -258,11 +258,11 @@ public class FranchiseSettlementFacade {
                                 .map(entry -> {
                                         String name = entry.getKey();
                                         List<SalesItem> group = entry.getValue();
-                                    int totalQty = (int) group.stream()
-                                            .distinct()
-                                            .count();
-                                    BigDecimal total = group.stream()
-                                            .map(SalesItem::getUnitPrice)
+                                    int totalQty = group.stream().mapToInt(item ->
+                                            item.getSales().getQuantity()).sum();
+                                    BigDecimal total = group.stream().map(item ->
+                                            item.getUnitPrice().multiply(BigDecimal.valueOf(
+                                                    item.getSales().getQuantity())))
                                             .reduce(BigDecimal.ZERO, BigDecimal::add);
                                         BigDecimal displayPrice = group.get(0).getUnitPrice();
                                         return new FranchiseSalesItemResponse(0, name, totalQty, displayPrice, total);

--- a/module-domain/domain-sales/src/main/java/com/chaing/domain/sales/dto/response/FranchiseSalesProductResponse.java
+++ b/module-domain/domain-sales/src/main/java/com/chaing/domain/sales/dto/response/FranchiseSalesProductResponse.java
@@ -1,6 +1,8 @@
 package com.chaing.domain.sales.dto.response;
 
 import com.chaing.domain.sales.entity.SalesItem;
+import com.chaing.domain.sales.exception.FranchiseSalesErrorCode;
+import com.chaing.domain.sales.exception.FranchiseSalesException;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -32,20 +34,30 @@ public record FranchiseSalesProductResponse(
         @NotNull
         String lot
 ) {
-    public static FranchiseSalesProductResponse from(SalesItem salesItem) {
+    public static FranchiseSalesProductResponse from(SalesItem salesItem, Integer quantity) {
         return FranchiseSalesProductResponse.builder()
                 .productCode(salesItem.getProductCode())
                 .productName(salesItem.getProductName())
-                .quantity(salesItem.getQuantity())
+                .quantity(quantity)
                 .unitPrice(salesItem.getUnitPrice())
-                .totalPrice(salesItem.getUnitPrice().multiply(BigDecimal.valueOf(salesItem.getQuantity())))
+                .totalPrice(salesItem.getUnitPrice().multiply(BigDecimal.valueOf(quantity)))
                 .lot(salesItem.getLot())
                 .build();
     }
 
     public static @NotNull List<FranchiseSalesProductResponse> from(List<SalesItem> salesItems) {
+
+        if(salesItems == null || salesItems.isEmpty()) {
+            throw new FranchiseSalesException(FranchiseSalesErrorCode.SALES_NOT_FOUND);
+        }
+
+        long countQuantity = salesItems.stream().distinct().count();
+        Integer quantity = Math.toIntExact(countQuantity);
+
         return salesItems.stream()
-                .map(FranchiseSalesProductResponse::from)
+                .map(salesItem -> {
+                    return FranchiseSalesProductResponse.from(salesItem, quantity);
+                })
                 .toList();
     }
 }

--- a/module-domain/domain-sales/src/main/java/com/chaing/domain/sales/dto/response/FranchiseSalesProductResponse.java
+++ b/module-domain/domain-sales/src/main/java/com/chaing/domain/sales/dto/response/FranchiseSalesProductResponse.java
@@ -45,19 +45,14 @@ public record FranchiseSalesProductResponse(
                 .build();
     }
 
-    public static @NotNull List<FranchiseSalesProductResponse> from(List<SalesItem> salesItems) {
+    public static @NotNull List<FranchiseSalesProductResponse> from(List<SalesItem> salesItems, Integer salesQuantity) {
 
         if(salesItems == null || salesItems.isEmpty()) {
             throw new FranchiseSalesException(FranchiseSalesErrorCode.SALES_NOT_FOUND);
         }
 
-        long countQuantity = salesItems.stream().distinct().count();
-        Integer quantity = Math.toIntExact(countQuantity);
-
         return salesItems.stream()
-                .map(salesItem -> {
-                    return FranchiseSalesProductResponse.from(salesItem, quantity);
-                })
+                .map(salesItem -> FranchiseSalesProductResponse.from(salesItem, salesQuantity))
                 .toList();
     }
 }

--- a/module-domain/domain-sales/src/main/java/com/chaing/domain/sales/dto/response/FranchiseSellItemResponse.java
+++ b/module-domain/domain-sales/src/main/java/com/chaing/domain/sales/dto/response/FranchiseSellItemResponse.java
@@ -18,22 +18,14 @@ public record FranchiseSellItemResponse(
         String productName,
 
         @NotNull
-        @Min(1)
-        Integer quantity,
+        BigDecimal unitPrice
 
-        @NotNull
-        BigDecimal unitPrice,
-
-        @NotNull
-        BigDecimal totalPrice
 ) {
     public static FranchiseSellItemResponse from(SalesItem salesItem) {
         return FranchiseSellItemResponse.builder()
                 .productCode(salesItem.getProductCode())
                 .productName(salesItem.getProductName())
-                .quantity(salesItem.getQuantity())
                 .unitPrice(salesItem.getUnitPrice())
-                .totalPrice(salesItem.getUnitPrice().multiply(BigDecimal.valueOf(salesItem.getQuantity())))
                 .build();
     }
 

--- a/module-domain/domain-sales/src/main/java/com/chaing/domain/sales/repository/impl/FranchiseSalesItemRepositoryImpl.java
+++ b/module-domain/domain-sales/src/main/java/com/chaing/domain/sales/repository/impl/FranchiseSalesItemRepositoryImpl.java
@@ -32,9 +32,9 @@ public class FranchiseSalesItemRepositoryImpl implements FranchiseSalesItemRepos
                         salesItem.createdAt,
                         salesItem.productCode,
                         salesItem.productName,
-                        salesItem.quantity,
+                        sales.quantity,
                         salesItem.unitPrice,
-                        salesItem.unitPrice.multiply(salesItem.quantity),
+                        salesItem.unitPrice.multiply(sales.quantity),
                         sales.isCanceled
                 ))
                 .from(salesItem)
@@ -54,7 +54,7 @@ public class FranchiseSalesItemRepositoryImpl implements FranchiseSalesItemRepos
                         salesItem.createdAt,
                         salesItem.productCode,
                         salesItem.productName,
-                        salesItem.quantity,
+                        sales.quantity,
                         salesItem.unitPrice,
                         sales.totalAmount,
                         sales.isCanceled
@@ -96,7 +96,7 @@ public class FranchiseSalesItemRepositoryImpl implements FranchiseSalesItemRepos
         DateExpression<java.sql.Date> salesDateExpr = Expressions.dateTemplate(
                 java.sql.Date.class, "DATE({0})", sales.createdAt);
 
-        var qtyExpr = salesItem.quantity.sum();
+        var qtyExpr = sales.quantity.sum();
 
         List<com.querydsl.core.Tuple> rows = queryFactory
                 .select(

--- a/module-domain/domain-sales/src/main/java/com/chaing/domain/sales/service/FranchiseSalesService.java
+++ b/module-domain/domain-sales/src/main/java/com/chaing/domain/sales/service/FranchiseSalesService.java
@@ -57,7 +57,7 @@ public class FranchiseSalesService {
                 .salesCode(sales.getSalesCode())
                 .salesDate(sales.getCreatedAt())
                 .products(
-                        FranchiseSalesProductResponse.from(salesItems)
+                        FranchiseSalesProductResponse.from(salesItems, sales.getQuantity())
                 )
                 .build();
     }


### PR DESCRIPTION
## 🔗 연관된 이슈
> 이슈 번호를 작성해주세요. (예: Closes #123)
- Closes #180 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- [x] salesItemRepository 내 quantity 관련 파라미터 변경
- [x] salesItem 정산 관련 로직 수정

## ✅ 테스트 결과
> 수행한 테스트와 결과를 요약해주세요. (예: 단위 테스트 전체 통과)
- [ ] 단위 테스트 (JUnit)
- [ ] 통합 테스트

---
### ✅ 변경 사항 체크리스트
- [ ] 커밋 메시지 컨벤션을 준수했나요?
- [ ] 불필요한 공백이나 주석을 제거했나요?
- [ ] 코드에 영향이 있는 부분에 대해 테스트를 작성했나요?
- [ ] 모든 테스트가 성공했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 가맹점 판매 항목 집계 시 품목별 수량 및 총액 계산이 판매 건의 수량을 기반으로 정확히 계산되도록 수정

* **리팩토링**
  * 판매 응답 데이터 구조 간소화로 불필요한 수량/총가격 필드 제거
  * 저장소 쿼리와 응답 생성 로직에서 수량 계산이 일관되게 적용되도록 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->